### PR TITLE
Fixing Swagger URL to include API in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ cd hortonworks-registry-0.1.0-SNAPSHOT
 
 # API doc
 
-http://localhost:9090/swagger/ ( make sure to change the port if you are using different port in the registry-dev.yaml config)
+http://localhost:9090/api/swagger/ ( make sure to change the port if you are using different port in the registry-dev.yaml config)
 


### PR DESCRIPTION
The swagger url in the doc was missing the "api" path.