### PR TITLE
Removed declared dependency on 2.10.x Scala so it's possible to crossbuild 2.11 Scala apps via SBT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
         <hadoop.version>2.7.1</hadoop.version>
         <kafka.version>0.10.0.1</kafka.version>
         <kafkaArtifact>kafka_2.10</kafkaArtifact>
-        <scalaVersion>2.10.5</scalaVersion>
         <avro.version>1.7.7</avro.version>
         <dropwizard.version>1.0.2</dropwizard.version>
         <jersey.version>2.22.1</jersey.version>
@@ -225,11 +224,6 @@
                         <artifactId>log4j</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scalaVersion}</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
This version (0.1.0-SNAPSHOT) builds fine.  I've been using this modification for crossbuilding our 2.11 Scala applications.