### PR TITLE
registry-docker

### DIFF
--- a/docker/images/registry/Dockerfile
+++ b/docker/images/registry/Dockerfile
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM centos:7.2.1511
+
+ARG REGISTRY_VERSION
+
+ENV JAVA_HOME /opt/jdk1.8.0_111/
+
+# Add Hortonworks Registry binary. Maven profile "-Pdocker" will place the binary in the correct location
+ADD hortonworks-registry-$REGISTRY_VERSION.tar.gz /
+
+# Install system dependencies
+RUN yum install -y wget
+
+# Install Java
+RUN wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz" \
+    && tar xzf jdk-8u111-linux-x64.tar.gz \
+    && mv jdk1.8.0_111 /opt \
+    && cd /opt/jdk1.8.0_111/ \
+    && alternatives --install /usr/bin/java java /opt/jdk1.8.0_111/bin/java 1
+
+CMD hortonworks-registry-$REGISTRY_VERSION/bin/registry-server-start.sh hortonworks-registry-$REGISTRY_VERSION/conf/registry-dev.yaml

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements. See the NOTICE file distributed with this work for additional
+information regarding copyright ownership. The ASF licenses this file to
+You under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>registries</artifactId>
+        <groupId>com.hortonworks.registries</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hortonworks-registries-docker</artifactId>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <!-- Profile for building official Docker images. Not bound to build phases since that would require anyone build to have the Docker engine installed on their machine -->
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.4.13</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <imageName>registry</imageName>
+                            <dockerDirectory>${project.basedir}/images/registry</dockerDirectory>
+                            <imageTags>
+                                <imageTag>${parent.version}</imageTag>
+                            </imageTags>
+                            <buildArgs>
+                                <REGISTRY_VERSION>${parent.version}</REGISTRY_VERSION>
+                            </buildArgs>
+                            <resources>
+                                <resource>
+                                    <targetPath>/</targetPath>
+                                    <directory>${project.basedir}/../registry-dist/target</directory>
+                                    <include>hortonworks-registry-${parent.version}.tar.gz</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>tag-registry</module>
         <module>schema-registry</module>
         <module>examples</module>
+        <module>docker</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Initial support for building Docker images via Maven. The image can be
built as part of the build process by using the Maven Profile
“-Pdocker” and does expect that “registry-dist” has been previously
built. The easiest way to ensure this is always including “-Pdist” with
the Maven command as well.