### PR TITLE
ISSUE#43 drop tables script is missing in the script

### DIFF
--- a/bootstrap/sql/mysql/drop_tables.sql
+++ b/bootstrap/sql/mysql/drop_tables.sql
@@ -1,0 +1,6 @@
+-- USE schema_registry;
+DROP TABLE IF EXISTS schema_serdes_mapping;
+DROP TABLE IF EXISTS schema_serdes_info;
+DROP TABLE IF EXISTS schema_field_info;
+DROP TABLE IF EXISTS schema_version_info;
+DROP TABLE IF EXISTS schema_metadata_info;


### PR DESCRIPTION
[drop_schemaregistry-tables.sql](https://github.com/hortonworks/registry/blob/master/schema-registry/core/src/main/resources/mysql/drop_schemaregistry-tables.sql) contains the script but [drop_tables.sql](https://github.com/hortonworks/registry/blob/master/bootstrap/sql/mysql/drop_tables.sql) is missing the same.