### PR TITLE
ISSUE-80: _orderByField should have been handled for inmemory storage manager

### DIFF
--- a/schema-registry/rest-service/src/test/java/com/hortonworks/registries/schemaregistry/avro/SingletonInmemoryStore.java
+++ b/schema-registry/rest-service/src/test/java/com/hortonworks/registries/schemaregistry/avro/SingletonInmemoryStore.java
@@ -16,6 +16,7 @@
 package com.hortonworks.registries.schemaregistry.avro;
 
 import com.hortonworks.registries.common.QueryParam;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.StorageManager;
@@ -62,6 +63,11 @@ public class SingletonInmemoryStore implements StorageManager {
     @Override
     public <T extends Storable> Collection<T> find(String namespace, List<QueryParam> queryParams) throws StorageException {
         return inMemoryStorageManager.find(namespace, queryParams);
+    }
+
+    @Override
+    public <T extends Storable> Collection<T> find(String namespace, List<QueryParam> queryParams, List<OrderByField> orderByFields) throws StorageException {
+        return inMemoryStorageManager.find(namespace, queryParams, orderByFields);
     }
 
     @Override

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/CacheBackedStorageManager.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/CacheBackedStorageManager.java
@@ -80,6 +80,11 @@ public class CacheBackedStorageManager implements StorageManager {
     }
 
     @Override
+    public <T extends Storable> Collection<T> find(String namespace, List<QueryParam> queryParams, List<OrderByField> orderByFields) throws StorageException {
+        return ((GuavaCache)cache).getDao().find(namespace, queryParams, orderByFields);
+    }
+
+    @Override
     public <T extends Storable> Collection<T> list(String namespace) throws StorageException {
         return dao.list(namespace);
     }

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/OrderByField.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/OrderByField.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hortonworks.registries.storage.impl.jdbc.provider.sql.query;
+package com.hortonworks.registries.storage;
 
 /**
  *

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/StorageManager.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/StorageManager.java
@@ -92,6 +92,19 @@ public interface StorageManager {
     <T extends Storable> Collection<T> find(String namespace, List<QueryParam> queryParams) throws StorageException;
 
     /**
+     * Returns the collection of storable entities in the given {@code namespace}, matching given {@code queryParams} and
+     * order by the given list of {@code orderByFields}
+     *
+     * @param namespace
+     * @param queryParams
+     * @param orderByFields
+     * @param <T>
+     * @return
+     * @throws StorageException when any storage error occurs
+     */
+    <T extends Storable> Collection<T> find(String namespace, List<QueryParam> queryParams, List<OrderByField> orderByFields) throws StorageException;
+
+    /**
      * Lists all {@link Storable} objects existing in the given namespace. If no entity is found, and empty list will be returned.
      * @param namespace
      * @return

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/JdbcStorageManager.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/JdbcStorageManager.java
@@ -18,6 +18,7 @@ package com.hortonworks.registries.storage.impl.jdbc;
 
 import com.hortonworks.registries.common.QueryParam;
 import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.PrimaryKey;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableFactory;
@@ -31,25 +32,21 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.factory.Pho
 import com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.factory.PostgresqlExecutor;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.QueryExecutor;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.MetadataHelper;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlSelectQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 //Use unique constraints on respective columns of a table for handling concurrent inserts etc.
 public class JdbcStorageManager implements StorageManager {
     private static final Logger log = LoggerFactory.getLogger(StorageManager.class);
     public static final String DB_TYPE = "db.type";
-    public static final String ORDER_BY_FIELDS_PARAM_NAME = "_orderByFields";
 
     private final StorableFactory storableFactory = new StorableFactory();
     private QueryExecutor queryExecutor;
@@ -113,20 +110,23 @@ public class JdbcStorageManager implements StorageManager {
             throws StorageException {
         log.debug("Searching for entries in table [{}] that match queryParams [{}]", namespace, queryParams);
 
-        List<QueryParam> filteredQueryParams =
-                queryParams != null
-                        ? queryParams.stream().filter(param -> !ORDER_BY_FIELDS_PARAM_NAME.equals(param.getName()))
-                        .collect(Collectors.toList())
-                        : Collections.emptyList();
-        List<OrderByField> orderByFields = getOrderByFields(queryParams);
+        return find(namespace, queryParams, Collections.emptyList());
+    }
 
-        if (filteredQueryParams.isEmpty()) {
+    @Override
+    public <T extends Storable> Collection<T> find(String namespace,
+                                                   List<QueryParam> queryParams,
+                                                   List<OrderByField> orderByFields) throws StorageException {
+
+        log.debug("Searching for entries in table [{}] that match queryParams [{}] and order by [{}]", namespace, queryParams, orderByFields);
+
+        if (queryParams == null || queryParams.isEmpty()) {
             return list(namespace, orderByFields);
         }
 
         Collection<T> entries = Collections.emptyList();
         try {
-            StorableKey storableKey = buildStorableKey(namespace, filteredQueryParams);
+            StorableKey storableKey = buildStorableKey(namespace, queryParams);
             if (storableKey != null) {
                 entries = queryExecutor.select(storableKey, orderByFields);
             }
@@ -144,38 +144,6 @@ public class JdbcStorageManager implements StorageManager {
         final Collection<T> entries = queryExecutor.select(namespace, orderByFields);
         log.debug("Querying table = [{}]\n\t returned [{}]", namespace, entries);
         return entries;
-    }
-
-    private List<OrderByField> getOrderByFields(List<QueryParam> queryParams) {
-        if(queryParams == null || queryParams.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<OrderByField> orderByFields = new ArrayList<>();
-        for (QueryParam queryParam : queryParams) {
-            if (ORDER_BY_FIELDS_PARAM_NAME.equals(queryParam.getName())) {
-                // _orderByFields=[<field-name>,<a/d>,]*
-                // example can be : _orderByFields=foo,a,bar,d
-                // order by foo with ascending then bar with descending
-                String value = queryParam.getValue();
-                String[] splitStrings = value.split(",");
-                for (int i = 0; i < splitStrings.length; i += 2) {
-                    String ascStr = splitStrings[i+1];
-                    boolean descending;
-                    if("a".equals(ascStr)) {
-                        descending = false;
-                    } else if("d".equals(ascStr)) {
-                        descending = true;
-                    } else {
-                        throw new IllegalArgumentException("Ascending or Descending identifier can only be 'a' or 'd' respectively.");
-                    }
-
-                    orderByFields.add(OrderByField.of(splitStrings[i], descending));
-                }
-            }
-        }
-
-        return orderByFields;
     }
 
     @Override

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/factory/MySqlExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/factory/MySqlExecutor.java
@@ -18,6 +18,7 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.mysql.factory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
@@ -27,7 +28,6 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlIn
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlInsertUpdateDuplicate;
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlSelectQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.AbstractQueryExecutor;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.util.Util;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/query/MySqlSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/query/MySqlSelectQuery.java
@@ -15,9 +15,9 @@
  */
 package com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query;
 
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSelectQuery;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/factory/PhoenixExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/factory/PhoenixExecutor.java
@@ -18,6 +18,7 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.factory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
@@ -29,7 +30,6 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.query.Phoen
 import com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.query.PhoenixSequenceIdQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.query.PhoenixUpsertQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.AbstractQueryExecutor;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.util.Util;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/query/PhoenixSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/query/PhoenixSelectQuery.java
@@ -15,9 +15,9 @@
  **/
 package com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.query;
 
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSelectQuery;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/factory/PostgresqlExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/factory/PostgresqlExecutor.java
@@ -21,6 +21,7 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.factory
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
@@ -31,7 +32,6 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.query.Po
 import com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.query.PostgresqlInsertUpdateDuplicate;
 import com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.query.PostgresqlSelectQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.AbstractQueryExecutor;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.util.Util;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/query/PostgresqlSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/query/PostgresqlSelectQuery.java
@@ -15,9 +15,9 @@
  */
 package com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.query;
 
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSelectQuery;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
@@ -16,12 +16,12 @@
 
 package com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory;
 
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableFactory;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.exception.NonIncrementalColumnException;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSelectQuery.java
@@ -17,6 +17,7 @@
  */
 package com.hortonworks.registries.storage.impl.jdbc.provider.sql.query;
 
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.StorableKey;
 
 import java.util.List;

--- a/storage/core/src/test/java/com/hortonworks/registries/storage/impl/jdbc/mysql/MySqlSelectQueryTest.java
+++ b/storage/core/src/test/java/com/hortonworks/registries/storage/impl/jdbc/mysql/MySqlSelectQueryTest.java
@@ -18,10 +18,10 @@
 package com.hortonworks.registries.storage.impl.jdbc.mysql;
 
 import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.PrimaryKey;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlSelectQuery;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/storage/core/src/test/java/com/hortonworks/registries/storage/impl/jdbc/postgres/PostgresSelectQueryTest.java
+++ b/storage/core/src/test/java/com/hortonworks/registries/storage/impl/jdbc/postgres/PostgresSelectQueryTest.java
@@ -18,11 +18,10 @@
 package com.hortonworks.registries.storage.impl.jdbc.postgres;
 
 import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.PrimaryKey;
 import com.hortonworks.registries.storage.StorableKey;
-import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlSelectQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.query.PostgresqlSelectQuery;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.OrderByField;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/storage/core/src/test/java/com/hortonworks/registries/storage/impl/memory/InmemoryManagerTest.java
+++ b/storage/core/src/test/java/com/hortonworks/registries/storage/impl/memory/InmemoryManagerTest.java
@@ -16,7 +16,6 @@
 package com.hortonworks.registries.storage.impl.memory;
 
 import com.hortonworks.registries.storage.DeviceInfoTest;
-import com.hortonworks.registries.storage.StorableTest;
 
 import java.util.Collections;
 
@@ -27,7 +26,7 @@ public class InmemoryManagerTest extends AbstractInMemoryStorageManagerTest {
 
     @Override
     protected void setStorableTests() {
-        storableTests = Collections.<StorableTest>singletonList(new DeviceInfoTest());
+        storableTests = Collections.singletonList(new DeviceInfoTest());
     }
 
 }


### PR DESCRIPTION
- orderByField query parsing is pushed to the service instead of keeping at JDBC storage manager level. 
- Added new API in `StorageManager` for order by fields.