### PR TITLE
ISSUE-172 Support Disabling Schemas

### DIFF
--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionInfo.java
@@ -51,18 +51,24 @@ public final class SchemaVersionInfo implements Serializable {
      * timestamp of the schema which is given in SchemaInfo
      */
     private Long timestamp;
+
+    /**
+     * if the schema version is disabled which is given in SchemaInfo
+     */
+    private Boolean disabled;
     
 
     @SuppressWarnings("unused")
     private SchemaVersionInfo() { /* Private constructor for Jackson JSON mapping */ }
 
-    public SchemaVersionInfo(Long id, String name, Integer version, String schemaText, Long timestamp, String description) {
+    public SchemaVersionInfo(Long id, String name, Integer version, String schemaText, Long timestamp, Boolean disabled, String description) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.version = version;
         this.schemaText = schemaText;
         this.timestamp = timestamp;
+        this.disabled = disabled != null ? disabled : Boolean.FALSE;
     }
 
     public Long getId() {
@@ -89,6 +95,10 @@ public final class SchemaVersionInfo implements Serializable {
         return timestamp;
     }
 
+    public Boolean isDisabled() {
+        return disabled != null && disabled;
+    }
+
     @Override
     public String toString() {
         return "SchemaVersionInfo{" +
@@ -97,8 +107,9 @@ public final class SchemaVersionInfo implements Serializable {
                 ", description='" + description + '\'' +
                 ", version=" + version +
                 ", schemaText='" + schemaText + '\'' +
-                ", timestamp=" + timestamp +
-                '}';
+                ", timestamp='" + timestamp + '\'' +
+                ", disabled=" + disabled +
+               '}';
     }
 
     @Override
@@ -113,7 +124,8 @@ public final class SchemaVersionInfo implements Serializable {
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (version != null ? !version.equals(that.version) : that.version != null) return false;
         if (schemaText != null ? !schemaText.equals(that.schemaText) : that.schemaText != null) return false;
-        return timestamp != null ? timestamp.equals(that.timestamp) : that.timestamp == null;
+        if (timestamp != null ? !timestamp.equals(that.timestamp) : that.timestamp != null) return false;
+        return disabled != null ? disabled.equals(that.disabled) : that.disabled == null;
 
     }
 
@@ -125,6 +137,7 @@ public final class SchemaVersionInfo implements Serializable {
         result = 31 * result + (version != null ? version.hashCode() : 0);
         result = 31 * result + (schemaText != null ? schemaText.hashCode() : 0);
         result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
+        result = 31 * result + (disabled != null ? disabled.hashCode() : 0);
         return result;
     }
 }

--- a/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroCompositeSchemasTest.java
+++ b/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroCompositeSchemasTest.java
@@ -72,7 +72,7 @@ public class AvroCompositeSchemasTest {
     }
 
     private SchemaVersionInfo cretaeSchemaVersionInfo(String name) throws IOException {
-        return new SchemaVersionInfo(1l, name, 1, getResourceText(name), System.currentTimeMillis(), "");
+        return new SchemaVersionInfo(1l, name, 1, getResourceText(name), System.currentTimeMillis(), false, "");
     }
 
     private String getResourceText(String name) throws IOException {

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/ISchemaRegistry.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/ISchemaRegistry.java
@@ -55,6 +55,12 @@ public interface ISchemaRegistry {
 
     SchemaVersionInfo getSchemaVersion(Long id) throws SchemaNotFoundException, InvalidSchemaException;
 
+    SchemaVersionInfo disableSchemaVersion(String schemaName, SchemaIdVersion id) throws SchemaNotFoundException, InvalidSchemaException;
+
+    SchemaVersionInfo enableSchemaVersion(String schemaName, SchemaIdVersion id) throws SchemaNotFoundException, InvalidSchemaException;
+
+    List<SchemaVersionInfo> disableAllVersions(String schemaName);
+
     List<SchemaVersionInfo> findAllVersions(String schemaName);
 
     SchemaVersionInfo getSchemaVersionInfo(SchemaVersionKey schemaVersionKey) throws SchemaNotFoundException;

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionStorable.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionStorable.java
@@ -39,6 +39,8 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
     public static final String SCHEMA_TEXT = "schemaText";
     public static final String TIMESTAMP = "timestamp";
     public static final String FINGERPRINT = "fingerprint";
+    public static final String DISABLED = "disabled";
+
 
     public static final Schema.Field ID_FIELD = Schema.Field.of(ID, Schema.Type.LONG);
 
@@ -50,7 +52,8 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
         Schema.Field.optional(DESCRIPTION, Schema.Type.STRING),
         Schema.Field.of(VERSION, Schema.Type.INTEGER),
         Schema.Field.of(TIMESTAMP, Schema.Type.LONG),
-        Schema.Field.of(FINGERPRINT, Schema.Type.STRING)
+        Schema.Field.of(FINGERPRINT, Schema.Type.STRING),
+        Schema.Field.of(DISABLED, Schema.Type.BOOLEAN)
     );
     
 
@@ -95,6 +98,11 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
      * Fingerprint of the schema.
      */
     private String fingerprint;
+
+    /**
+     * If the schema is disabled.
+     */
+    private Boolean disabled = Boolean.FALSE;
 
     public SchemaVersionStorable() {
     }
@@ -181,6 +189,14 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
         this.fingerprint = fingerprint;
     }
 
+    public Boolean getDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(Boolean disabled) {
+        this.disabled = disabled;
+    }
+
     public String getName() {
         return name;
     }
@@ -190,7 +206,7 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
     }
 
     public SchemaVersionInfo toSchemaVersionInfo() {
-        return new SchemaVersionInfo(id, name, version, schemaText, timestamp, description);
+        return new SchemaVersionInfo(id, name, version, schemaText, timestamp, disabled, description);
     }
 
     @Override
@@ -204,7 +220,8 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
                 ", version=" + version +
                 ", timestamp=" + timestamp +
                 ", fingerprint='" + fingerprint + '\'' +
-                '}';
+                ", disabled=" + disabled +
+               '}';
     }
 
     @Override
@@ -222,6 +239,7 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
         if (schemaText != null ? !schemaText.equals(that.schemaText) : that.schemaText != null) return false;
         if (version != null ? !version.equals(that.version) : that.version != null) return false;
         if (timestamp != null ? !timestamp.equals(that.timestamp) : that.timestamp != null) return false;
+        if (disabled != null ? !disabled.equals(that.disabled) : that.disabled != null) return false;
         return fingerprint != null ? fingerprint.equals(that.fingerprint) : that.fingerprint == null;
 
     }
@@ -235,6 +253,7 @@ public class SchemaVersionStorable extends AbstractVersionedStorable {
         result = 31 * result + (schemaText != null ? schemaText.hashCode() : 0);
         result = 31 * result + (version != null ? version.hashCode() : 0);
         result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
+        result = 31 * result + (disabled != null ? disabled.hashCode() : 0);
         result = 31 * result + (fingerprint != null ? fingerprint.hashCode() : 0);
         return result;
     }

--- a/schema-registry/serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/MessageContextBasedAvroSerDesTest.java
+++ b/schema-registry/serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/MessageContextBasedAvroSerDesTest.java
@@ -56,7 +56,7 @@ public class MessageContextBasedAvroSerDesTest {
         SchemaVersionInfo schemaVersionInfo = new SchemaVersionInfo(1l, input.getName().toString(), schemaIdVersion.getVersion(),
                                                                     input.getSchema().toString(),
                                                                     System.currentTimeMillis(),
-                                                                    "");
+                                                                    false, "");
 
         new Expectations() {
             {

--- a/schema-registry/serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/SchemaVersionProtocolHandlerTest.java
+++ b/schema-registry/serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/SchemaVersionProtocolHandlerTest.java
@@ -70,6 +70,7 @@ public class SchemaVersionProtocolHandlerTest {
         SchemaVersionInfo schemaVersionInfo = new SchemaVersionInfo(id, input.getName().toString(), schemaIdVersion.getVersion(),
                                                                     input.getSchema().toString(),
                                                                     System.currentTimeMillis(),
+                                                                    false,
                                                                     "some device");
 
         new Expectations() {


### PR DESCRIPTION
Add ability to disable schema's this will mean when disabled, a schema will no longer partake in compatibilty checks (e.g. allowing disabling an accidental registration). 
Also address's ISSUE-173, by providing helper method ability to disable all versions of a given schema (for sakes of topic deletion)