### PR TITLE
ISSUE-184 Missing column in schema_metadata_info tables.

### DIFF
--- a/bootstrap/sql/mysql/create_tables.sql
+++ b/bootstrap/sql/mysql/create_tables.sql
@@ -27,6 +27,14 @@ CREATE TABLE IF NOT EXISTS schema_metadata_info (
   UNIQUE KEY (id)
 );
 
+-- Version 0.3.0
+IF NOT EXISTS( SELECT NULL
+            FROM INFORMATION_SCHEMA.COLUMNS
+           WHERE table_name = 'schema_metadata_info'
+             AND column_name = 'validationLevel')  THEN
+  ALTER TABLE `schema_metadata_info` ADD `validationLevel` VARCHAR(256) NOT NULL DEFAULT 'ALL';
+END IF;
+
 CREATE TABLE IF NOT EXISTS schema_version_info (
   id               BIGINT AUTO_INCREMENT NOT NULL,
   description      TEXT,

--- a/bootstrap/sql/postgresql/create_tables.sql
+++ b/bootstrap/sql/postgresql/create_tables.sql
@@ -26,6 +26,10 @@ CREATE TABLE IF NOT EXISTS schema_metadata_info (
   UNIQUE("id","name")
 );
 
+-- Version 0.3.0
+ALTER TABLE schema_metadata_info
+  ADD validationLevel IF NOT EXISTS VARCHAR(256) NOT NULL DEFAULT 'ALL';
+
 CREATE TABLE IF NOT EXISTS schema_version_info (
   "id"            SERIAL UNIQUE NOT NULL,
   "description"    TEXT,


### PR DESCRIPTION
Add to create scripts update to add column if not existing. 
n.b. postgres statement is 9.6 compatible only.