### PR TITLE
Integrate Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+language: java
+jdk:
+  - oraclejdk8
+install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
+script:
+  - /bin/bash ./dev-tools/travis/travis-script.sh `pwd`
+sudo: required
+cache:
+  directories:
+    - "$HOME/.m2/repository"
+    - "$NVM_DIR"

--- a/dev-tools/travis/print-errors-from-test-reports.py
+++ b/dev-tools/travis/print-errors-from-test-reports.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import glob
+import traceback
+from xml.etree.ElementTree import ElementTree
+
+def print_detail_information(testcase, fail_or_error):
+    print "-" * 50
+    print "classname: %s / testname: %s" % (testcase.get("classname"), testcase.get("name"))
+    print fail_or_error.text
+    stdout = testcase.find("system-out")
+    if stdout != None:
+        print "-" * 20, "system-out", "-"*20
+        print stdout.text
+    stderr = testcase.find("system-err")
+    if stderr != None:
+        print "-" * 20, "system-err", "-"*20
+        print stderr.text
+    print "-" * 50
+
+
+def print_error_reports_from_report_file(file_path):
+    tree = ElementTree()
+    try:
+        tree.parse(file_path)
+    except:
+        print "-" * 50
+        print "Error parsing %s"%file_path
+        f = open(file_path, "r");
+        print f.read();
+        print "-" * 50
+        return
+
+    testcases = tree.findall(".//testcase")
+    for testcase in testcases:
+        error = testcase.find("error")
+        if error is not None:
+            print_detail_information(testcase, error)
+
+        fail = testcase.find("fail")
+        if fail is not None:
+            print_detail_information(testcase, fail)
+
+        failure = testcase.find("failure")
+        if failure is not None:
+            print_detail_information(testcase, failure)
+
+
+def main(report_dir_path):
+    for test_report in glob.iglob(report_dir_path + '/*.xml'):
+        file_path = os.path.abspath(test_report)
+        try:
+            print "Checking %s" % test_report
+            print_error_reports_from_report_file(file_path)
+        except Exception, e:
+            print "Error while reading report file, %s" % file_path
+            print "Exception: %s" % e
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    if sys.argv < 2:
+        print "Usage: %s [report dir path]" % sys.argv[0]
+        sys.exit(1)
+
+    main(sys.argv[1])

--- a/dev-tools/travis/ratprint.py
+++ b/dev-tools/travis/ratprint.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import sys
+import re
+
+p = re.compile('Unapproved licenses:\s*([^\s\*]*).*\*\*\*')
+
+with open (sys.argv[1]) as ratfile:
+  rat = ratfile.read().replace('\n','')
+
+matches = p.search(rat)
+failed =  matches.group(1)
+
+if re.search('\S', failed):
+  print failed

--- a/dev-tools/travis/save-logs.py
+++ b/dev-tools/travis/save-logs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import subprocess
+from datetime import datetime, timedelta
+
+def main(file, cmd):
+    print cmd, "writing to", file
+    out = open(file, "w")
+    count = 0
+    process = subprocess.Popen(cmd,
+                           stderr=subprocess.STDOUT,
+                           stdout=subprocess.PIPE)
+
+    start = datetime.now()
+    nextPrint = datetime.now() + timedelta(seconds=1)
+    # wait for the process to terminate
+    pout = process.stdout
+    line = pout.readline()
+    while line:
+        count = count + 1
+        if datetime.now() > nextPrint:
+            diff = datetime.now() - start
+            sys.stdout.write("\r%d seconds %d log lines"%(diff.seconds, count))
+            sys.stdout.flush()
+            nextPrint = datetime.now() + timedelta(seconds=10)
+        out.write(line)
+        line = pout.readline()
+    out.close()
+    errcode = process.wait()
+    diff = datetime.now() - start
+    sys.stdout.write("\r%d seconds %d log lines"%(diff.seconds, count))
+    print
+    print cmd, "done", errcode
+    return errcode
+
+if __name__ == "__main__":
+    if sys.argv < 1:
+        print "Usage: %s [file info]" % sys.argv[0]
+        sys.exit(1)
+
+    sys.exit(main(sys.argv[1], sys.argv[2:]))

--- a/dev-tools/travis/travis-install.sh
+++ b/dev-tools/travis/travis-install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+echo "Python version :  " `python -V 2>&1`
+echo "Maven version  :  " `mvn -v`
+
+SRC_ROOT_DIR=$1
+
+TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd ${SRC_ROOT_DIR}
+python ${TRAVIS_SCRIPT_DIR}/save-logs.py "install.txt" mvn clean install -DskipTests --batch-mode
+BUILD_RET_VAL=$?
+
+if [[ "$BUILD_RET_VAL" != "0" ]];
+then
+  cat "install.txt"
+  echo "Looking for unapproved licenses"
+  for rat in `find . -name rat.txt`;
+  do
+    python ${TRAVIS_SCRIPT_DIR}/ratprint.py "${rat}"
+  done
+fi
+
+exit ${BUILD_RET_VAL}

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+echo "Python version :  " `python -V 2>&1`
+echo "Maven version  :  " `mvn -v`
+
+SRC_ROOT_DIR=$1
+
+TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd ${SRC_ROOT_DIR}
+  
+# Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
+export MAVEN_OPTS="-Xmx1024m"
+
+mvn --batch-mode test -fae 
+BUILD_RET_VAL=$?
+
+for dir in `find . -type d -and -wholename \*/target/\*-reports`;
+do
+echo "Looking for errors in ${dir}"
+python ${TRAVIS_SCRIPT_DIR}/print-errors-from-test-reports.py "${dir}"
+done
+
+exit ${BUILD_RET_VAL}


### PR DESCRIPTION
* script codes are borrowed from Apache Storm (license block is kept)

I guess we didn't check RAT, but at some time we may want to check RAT (regardless of HWX license header or Apache license header or whatever) so I'm leaving RAT related script.

Unlike storm-core, the output of unit tests is not suppressed. But current output log file is 2M and limit for Travis CI is 10M which makes me feel safe.

I'm also open to integrate with other CI services. Just would like to ensure each PR can be verified.
(I meant it doesn't break the build and unit tests are successful.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hortonworks/registry/187)
<!-- Reviewable:end -->
