### PR TITLE
ISSUE-213 POJOs are made to be backward compatible

### DIFF
--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/AggregatedSchemaMetadataInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/AggregatedSchemaMetadataInfo.java
@@ -17,12 +17,15 @@
  */
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.Collection;
 
 /**
  * This class represents aggregated information about schema metadata which includes versions and mapped serdes.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AggregatedSchemaMetadataInfo implements Serializable {
 
     private static final long serialVersionUID = -414992394022547720L;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/CompatibilityResult.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/CompatibilityResult.java
@@ -15,11 +15,14 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class CompatibilityResult implements Serializable {
     public static final CompatibilityResult SUCCESS = new CompatibilityResult(true, null);
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/ConfigEntry.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/ConfigEntry.java
@@ -27,6 +27,8 @@ import java.util.Collections;
  */
 public final class ConfigEntry<T> implements Serializable {
 
+    private static final long serialVersionUID = -3408548579276359761L;
+
     private final String name;
     private final Class<? extends T> type;
     private final String description;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaFieldInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaFieldInfo.java
@@ -15,12 +15,17 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaFieldInfo implements Serializable {
+    private static final long serialVersionUID = -6194661942575334254L;
+
     public static final String ID = "id";
     public static final String SCHEMA_INSTANCE_ID = "schemaInstanceId";
     public static final String TIMESTAMP = "timestamp";

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaIdVersion.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaIdVersion.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -25,6 +26,7 @@ import java.io.Serializable;
  *
  * It is not necessary that all fields are always available but the minimum information to find schema version is available.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaIdVersion implements Serializable {
     private static final long serialVersionUID = 6081264497288914406L;
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadata.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadata.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
@@ -24,6 +25,7 @@ import java.io.Serializable;
 /**
  * This class is about metadata of a schema which includes name, type, schemaGroup, description, compatibility and evolve.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaMetadata implements Serializable {
 
     private static final long serialVersionUID = -6880986623123299254L;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadataInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadataInfo.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -24,7 +25,10 @@ import java.io.Serializable;
  * There can be only one instance with the same name.
  * New versions of the schema can be registered for the given {@link SchemaMetadataInfo} by giving {@link SchemaVersion} instances.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaMetadataInfo implements Serializable {
+
+    private static final long serialVersionUID = 8083699103887496439L;
 
     /**
      * metadata about the schema

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersion.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersion.java
@@ -15,12 +15,17 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  * This class represents details about versioned instance of a schema which includes description and schema text.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaVersion implements Serializable {
+    private static final long serialVersionUID = 1664618495690787804L;
+
     private String description;
     private String schemaText;
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionInfo.java
@@ -15,12 +15,17 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaVersionInfo implements Serializable {
+
+    private static final long serialVersionUID = -669711262227194948L;
 
     /**
      * global unique id of this schema instance

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionKey.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionKey.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -22,6 +23,7 @@ import java.io.Serializable;
 /**
  * This class contains schema name and version.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaVersionKey implements Serializable {
 
     private static final long serialVersionUID = 1779747592974345866L;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesInfo.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -22,7 +23,10 @@ import java.io.Serializable;
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SerDesInfo implements Serializable {
+    private static final long serialVersionUID = -3756866955883733874L;
+
     private Long id;
     private Long timestamp;
     private SerDesPair serDesPair;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesPair.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesPair.java
@@ -17,12 +17,17 @@
  */
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SerDesPair implements Serializable {
+    private static final long serialVersionUID = -1291992612139840722L;
+
     private String name;
     private String description;
     private String fileId;

--- a/schema-registry/rest-service/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaRegistryClientTest.java
+++ b/schema-registry/rest-service/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaRegistryClientTest.java
@@ -371,6 +371,7 @@ public class AvroSchemaRegistryClientTest extends AbstractAvroSchemaRegistryCien
         return schemaRegistryClient.uploadFile(inputStream);
     }
 
+
     @Test
     public void testSchemaVersionDeletion() throws Exception {
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/OrderBy.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/OrderBy.java
@@ -17,12 +17,17 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OrderBy implements Serializable {
+    private static final long serialVersionUID = 8220102056152801315L;
+
     private String fieldName;
     private boolean asc;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/Predicate.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/Predicate.java
@@ -17,12 +17,17 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Predicate implements Serializable {
+    private static final long serialVersionUID = 3928533466168563000L;
+
     public enum Operation {EQ, LT, GT, LTE, GTE, CONTAINS}
 
     private String field;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/PredicateCombinerPair.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/PredicateCombinerPair.java
@@ -17,12 +17,16 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredicateCombinerPair implements Serializable {
+    private static final long serialVersionUID = 8860616526693470116L;
     private Predicate predicate;
     private WhereClauseCombiner.Operation combinerOperation;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/SearchQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/SearchQuery.java
@@ -17,6 +17,8 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +27,9 @@ import java.util.List;
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SearchQuery implements Serializable {
+    private static final long serialVersionUID = 3394075873934901992L;
     private String nameSpace;
     private List<OrderBy> orderByFields;
     private WhereClause whereClause;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/WhereClause.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/WhereClause.java
@@ -17,6 +17,8 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +37,10 @@ import java.util.List;
  *
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WhereClause implements Serializable {
+    private static final long serialVersionUID = 901279529557954101L;
+
     protected List<PredicateCombinerPair> predicateCombinerPairs;
 
     private WhereClause() {


### PR DESCRIPTION
This allows schema registry clients with earlier versions to send old POJOs to new versions of SchemaRegistry server and deserialization will not look for missing fields in respective POJOs SchemaRegsitry server.