### PR TITLE
Aligning the schema_version_state ddl between postgres and mysql

### DIFF
--- a/bootstrap/sql/postgresql/v002__create_schema_version_state.sql
+++ b/bootstrap/sql/postgresql/v002__create_schema_version_state.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS schema_version_state (
   "stateId"         SMALLINT       NOT NULL,
   "sequence"        INT           NOT NULL,
   "timestamp"       BIGINT        NOT NULL,
-  "details"         VARCHAR(255)  NOT NULL,
+  "details"         VARCHAR(255),
   PRIMARY KEY ("schemaVersionId", "stateId", "sequence"),
   UNIQUE ("id")
 );


### PR DESCRIPTION
This resolves issue #241 by making the details column nullable for postgres. 