### PR TITLE
ISSUE:226 Oracle database support

### DIFF
--- a/bootstrap/sql/oracle/v001__create_table.sql
+++ b/bootstrap/sql/oracle/v001__create_table.sql
@@ -1,0 +1,96 @@
+-- Copyright 2016 Hortonworks.;
+-- ;
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.;
+-- You may obtain a copy of the License at;
+-- ;
+--    http://www.apache.org/licenses/LICENSE-2.0;
+-- ;
+-- Unless required by applicable law or agreed to in writing, software;
+-- distributed under the License is distributed on an "AS IS" BASIS,;
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.;
+-- See the License for the specific language governing permissions and;
+-- limitations under the License.;
+-- ;
+-- THE NAMES OF THE TABLE COLUMNS MUST MATCH THE NAMES OF THE CORRESPONDING CLASS MODEL FIELDS;
+-- ;
+
+CREATE TABLE "schema_metadata_info" (
+  "id"              NUMBER(19,0)           NOT NULL,
+  "type"            VARCHAR2(255)          NOT NULL,
+  "schemaGroup"     VARCHAR2(255)          NOT NULL,
+  "name"            VARCHAR2(255)          NOT NULL,
+  "compatibility"   VARCHAR2(255)          NOT NULL,
+  "validationLevel" VARCHAR2(255)          NOT NULL, -- added in 0.3.1, table should be altered to add this column from earlier versions.
+  "description"     VARCHAR2(4000),
+  "evolve"          NUMBER(1)              NOT NULL,
+  "timestamp"       NUMBER(19,0)           NOT NULL,
+  CONSTRAINT schema_metadata_info_pk PRIMARY KEY ("name"),
+  CONSTRAINT schema_metadata_info_uk UNIQUE ("id")
+);
+
+CREATE TABLE "schema_version_info" (
+  "id"               NUMBER(19,0)          NOT NULL,
+  "description"      VARCHAR2(4000),
+  "schemaText"       CLOB                  NOT NULL,
+  "fingerprint"      VARCHAR2(4000)        NOT NULL,
+  "version"          NUMBER(10,0)          NOT NULL,
+  "schemaMetadataId" NUMBER(19,0)          NOT NULL,
+  "timestamp"        NUMBER(19,0)          NOT NULL,
+  "state"            NUMBER(3,0)           NOT NULL,
+  "name"             VARCHAR2(255)         NOT NULL,
+  CONSTRAINT schema_version_info_uk_id UNIQUE ("id"),
+  CONSTRAINT schema_version_info_uk_metadata_id_version UNIQUE ("schemaMetadataId", "version"),
+  CONSTRAINT schema_version_info_pk PRIMARY KEY ("name", "version"),
+  CONSTRAINT schema_version_info_fk_schema_metadata_info_id FOREIGN KEY ("schemaMetadataId") REFERENCES "schema_metadata_info" ("id") ON DELETE CASCADE,
+  CONSTRAINT schema_version_info_fk_schema_metadata_info_name FOREIGN KEY ("name") REFERENCES "schema_metadata_info" ("name") ON DELETE CASCADE
+);
+
+CREATE TABLE "schema_field_info" (
+  "id"               NUMBER(19,0)          NOT NULL,
+  "schemaInstanceId" NUMBER(19,0)          NOT NULL,
+  "timestamp"        NUMBER(19,0)          NOT NULL,
+  "name"             VARCHAR2(255)         NOT NULL,
+  "fieldNamespace"   VARCHAR2(255),
+  "type"             VARCHAR2(255)         NOT NULL,
+  CONSTRAINT schema_field_info_pk PRIMARY KEY ("id"),
+  CONSTRAINT schema_field_info_fk_schema_version_id FOREIGN KEY ("schemaInstanceId") REFERENCES "schema_version_info" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE "schema_serdes_info" (
+  "id"                    NUMBER(19,0)          NOT NULL,
+  "description"           VARCHAR2(4000),
+  "name"                  VARCHAR2(4000)        NOT NULL,
+  "fileId"                VARCHAR2(4000)        NOT NULL,
+  "serializerClassName"   VARCHAR2(4000)        NOT NULL,
+  "deserializerClassName" VARCHAR2(4000)        NOT NULL,
+  "timestamp"             NUMBER(19,0)          NOT NULL,
+  CONSTRAINT schema_serdes_info_pk PRIMARY KEY ("id")
+);
+
+CREATE TABLE "schema_serdes_mapping" (
+  "schemaMetadataId" NUMBER(19,0) NOT NULL,
+  "serDesId"         NUMBER(19,0) NOT NULL,
+  CONSTRAINT schema_serdes_mapping_pk PRIMARY KEY ("schemaMetadataId", "serDesId")
+);
+
+CREATE TABLE "schema_version_state" (
+  "id"              NUMBER(19,0)          NOT NULL,
+  "schemaVersionId" NUMBER(19,0)          NOT NULL,
+  "stateId"         NUMBER(3,0)           NOT NULL,
+  "sequence"        NUMBER(10,0)          NOT NULL,
+  "timestamp"       NUMBER(19,0)          NOT NULL,
+  "details"         BLOB,
+  CONSTRAINT schema_version_state_pk PRIMARY KEY ("schemaVersionId", "stateId", "sequence"),
+  CONSTRAINT schema_version_state_uk UNIQUE ("id")
+);
+
+
+-- User should have CREATE SEQUENCE privilege to create sequnce which is will be used to get unique id for primary key
+
+CREATE SEQUENCE schema_metadata_info__sequence START WITH 1 INCREMENT BY 1 MAXVALUE 10000000000000000000;
+CREATE SEQUENCE schema_version_info__sequence START WITH 1 INCREMENT BY 1 MAXVALUE 10000000000000000000;
+CREATE SEQUENCE schema_field_info__sequence START WITH 1 INCREMENT BY 1 MAXVALUE 10000000000000000000;
+CREATE SEQUENCE schema_serdes_info__sequence START WITH 1 INCREMENT BY 1 MAXVALUE 10000000000000000000;
+CREATE SEQUENCE schema_serdes_mapping__sequence START WITH 1 INCREMENT BY 1 MAXVALUE 10000000000000000000;
+CREATE SEQUENCE schema_version_state__sequence START WITH 1 INCREMENT BY 1 MAXVALUE 10000000000000000000;

--- a/conf/registry.yaml.oracle.example
+++ b/conf/registry.yaml.oracle.example
@@ -1,0 +1,78 @@
+# registries configuration
+modules:
+  - name: schema-registry
+    className: com.hortonworks.registries.schemaregistry.webservice.SchemaRegistryModule
+    config:
+      schemaProviders:
+        - providerClass: "com.hortonworks.registries.schemaregistry.avro.AvroSchemaProvider"
+          defaultSerializerClass: "com.hortonworks.registries.schemaregistry.serdes.avro.AvroSnapshotSerializer"
+          defaultDeserializerClass: "com.hortonworks.registries.schemaregistry.serdes.avro.AvroSnapshotDeserializer"
+      # schema cache properties
+      # inmemory schema versions cache size
+      schemaCacheSize: 10000
+      # inmemory schema version cache entry expiry interval after access
+      schemaCacheExpiryInterval: 3600
+
+servletFilters:
+# - className: "com.hortonworks.registries.auth.server.AuthenticationFilter"
+#   params:
+#     type: "kerberos"
+#     kerberos.principal: "HTTP/streamline-ui-host.com"
+#     kerberos.keytab: "/vagrant/keytabs/http.keytab"
+#     kerberos.name.rules: "RULE:[2:$1@$0]([jt]t@.*EXAMPLE.COM)s/.*/$MAPRED_USER/ RULE:[2:$1@$0]([nd]n@.*EXAMPLE.COM)s/.*/$HDFS_USER/DEFAULT"
+ - className: "com.hortonworks.registries.schemaregistry.webservice.RewriteUriFilter"
+   params:
+     # value format is [<targetpath>,<paths-should-be-redirected-to>,*|]*
+     # below /subjects and /schemas/ids are forwarded to /api/v1/confluent
+     forwardPaths: "/api/v1/confluent,/subjects/*,/schemas/ids/*"
+     redirectPaths: "/ui/,/"
+
+# HA configuration
+#haConfig:
+#  className: com.hortonworks.registries.ha.zk.ZKLeadershipParticipant
+#  config:
+#    # This url is a list of ZK servers separated by ,
+#    connect.url: "localhost:2181"
+#    # root node prefix in ZK for this instance
+#    root: "/registry"
+#    session.timeout.ms: 30000
+#    connection.timeout.ms: 20000
+#    retry.limit: 5
+#    retry.base.sleep.time.ms: 1000
+#    retry.max.sleep.time.ms: 5000
+
+# Filesystem based jar storage
+fileStorageConfiguration:
+  className: "com.hortonworks.registries.common.util.LocalFileSystemStorage"
+  properties:
+    directory: "/tmp/schema-registry/jars"
+
+# MySQL based jdbc provider configuration is:
+storageProviderConfiguration:
+ providerClass: "com.hortonworks.registries.storage.impl.jdbc.JdbcStorageManager"
+ properties:
+   db.type: "oracle"
+   queryTimeoutInSecs: 5
+   db.properties:
+     dataSourceClassName: "oracle.jdbc.pool.OracleDataSource"
+     dataSource.url: "jdbc:oracle:thin:@localhost:1521/orclpdb1.localdomain"
+     dataSource.user: "registry_user"
+     dataSource.password: "registry_user_passwd"
+
+#swagger configuration
+swagger:
+  resourcePackage: com.hortonworks.registries.schemaregistry.webservice
+
+#enable CORS, may want to disable in production
+enableCors: false
+
+server:
+  applicationConnectors:
+    - type: http
+      port: 9090
+
+# Logging settings.
+logging:
+  level: INFO
+  loggers:
+    com.hortonworks.registries: INFO

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionLifecycleManager.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionLifecycleManager.java
@@ -530,6 +530,7 @@ public class SchemaVersionLifecycleManager {
             stateStorable.setSequence(schemaVersionLifecycleContext.getSequence() + 1);
             stateStorable.setStateId(stateId);
             stateStorable.setTimestamp(System.currentTimeMillis());
+            stateStorable.setId(storageManager.nextId(SchemaVersionStateStorable.NAME_SPACE));
 
             storageManager.add(stateStorable);
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/query/MySqlQueryUtils.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/query/MySqlQueryUtils.java
@@ -18,7 +18,9 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query;
 import com.hortonworks.registries.storage.exception.NonIncrementalColumnException;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.MetadataHelper;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.DefaultStorageDataTypeContext;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.StorageDataTypeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,11 +36,13 @@ import java.util.regex.Pattern;
 public class MySqlQueryUtils {
     private static final Logger log = LoggerFactory.getLogger(MySqlQueryUtils.class);
 
+    private static final StorageDataTypeContext STORAGE_DATA_TYPE_CONTEXT = new DefaultStorageDataTypeContext();
+
     private MySqlQueryUtils() {
     }
 
     public static long nextIdMySql(Connection connection, String namespace, int queryTimeoutSecs) throws SQLException {
-        if (!MetadataHelper.isAutoIncrement(connection, namespace, queryTimeoutSecs)) {
+        if (!MetadataHelper.isAutoIncrement(connection, namespace, queryTimeoutSecs, STORAGE_DATA_TYPE_CONTEXT)) {
             throw new NonIncrementalColumnException();
         }
 
@@ -51,7 +55,7 @@ public class MySqlQueryUtils {
 
     private static ResultSet getResultSet(Connection connection, int queryTimeoutSecs, String sql) throws SQLException {
         final MySqlQuery sqlBuilder = new MySqlQuery(sql);
-        return PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs),
+        return PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), STORAGE_DATA_TYPE_CONTEXT,
                 sqlBuilder).getPreparedStatement(sqlBuilder).executeQuery();
     }
 
@@ -64,7 +68,7 @@ public class MySqlQueryUtils {
     }
 
     public static long nextIdH2(Connection connection, String namespace, int queryTimeoutSecs) throws SQLException {
-        if (!MetadataHelper.isAutoIncrement(connection, namespace, queryTimeoutSecs)) {
+        if (!MetadataHelper.isAutoIncrement(connection, namespace, queryTimeoutSecs, STORAGE_DATA_TYPE_CONTEXT)) {
             throw new NonIncrementalColumnException();
         }
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/query/MySqlSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/query/MySqlSelectQuery.java
@@ -54,6 +54,11 @@ public class MySqlSelectQuery extends AbstractSelectQuery {
     }
 
     @Override
+    protected String tableNameEncloser() {
+        return "`";
+    }
+
+    @Override
     protected void initParameterizedSql() {
         sql = "SELECT * FROM " + tableName;
         //where clause is defined by columns specified in the PrimaryKey

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/exception/OracleQueryException.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/exception/OracleQueryException.java
@@ -14,30 +14,19 @@
  * limitations under the License.
  **/
 
-package com.hortonworks.registries.storage.tool;
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.exception;
 
-public enum DatabaseType {
+public class OracleQueryException extends RuntimeException {
 
-    MYSQL("mysql"),
-    POSTGRES("postgresql"),
-    ORACLE("oracle");
-
-    private final String value;
-
-    DatabaseType(String dbType) {
-        value = dbType;
+    public OracleQueryException(Throwable cause) {
+        super(cause);
     }
 
-    @Override
-    public String toString() {
-        return value;
+    public OracleQueryException(String message, Throwable cause) {
+        super(message, cause);
     }
 
-    public static DatabaseType fromValue(String otherValue) {
-        for (DatabaseType databaseType : values()) {
-            if (databaseType.value.equals(otherValue))
-                return databaseType;
-        }
-        throw new IllegalArgumentException("Unknown Database Type : " + otherValue);
+    public OracleQueryException(String message) {
+        super(message);
     }
 }

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/factory/OracleExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/factory/OracleExecutor.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.factory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import com.hortonworks.registries.storage.OrderByField;
+import com.hortonworks.registries.storage.Storable;
+import com.hortonworks.registries.storage.StorableKey;
+import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
+import com.hortonworks.registries.storage.impl.jdbc.connection.ConnectionBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.connection.HikariCPConnectionBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query.OracleDeleteQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query.OracleInsertQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query.OracleInsertUpdateDuplicate;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query.OracleSelectQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query.OracleSequenceIdQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.statement.OracleDataTypeContext;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.AbstractQueryExecutor;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.util.Util;
+import com.hortonworks.registries.storage.search.SearchQuery;
+import com.zaxxer.hikari.HikariConfig;
+
+import java.sql.Connection;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public class OracleExecutor extends AbstractQueryExecutor {
+
+    private static final OracleDataTypeContext ORACLE_DATA_TYPE_CONTEXT = new OracleDataTypeContext();
+
+    public OracleExecutor(ExecutionConfig config, ConnectionBuilder connectionBuilder) {
+        super(config, connectionBuilder, ORACLE_DATA_TYPE_CONTEXT);
+    }
+
+    public OracleExecutor(ExecutionConfig config, ConnectionBuilder connectionBuilder, CacheBuilder<SqlQuery, PreparedStatementBuilder> cacheBuilder) {
+        super(config, connectionBuilder, cacheBuilder, ORACLE_DATA_TYPE_CONTEXT);
+    }
+
+
+    @Override
+    public void insert(Storable storable) {
+        executeUpdate(new OracleInsertQuery(storable));
+    }
+
+    @Override
+    public void insertOrUpdate(final Storable storable) {
+        executeUpdate(new OracleInsertUpdateDuplicate(storable));
+    }
+
+    public void delete(StorableKey storableKey) {
+        executeUpdate(new OracleDeleteQuery(storableKey));
+    }
+
+    @Override
+    public <T extends Storable> Collection<T> select(final String namespace) {
+        return executeQuery(namespace, new OracleSelectQuery(namespace));
+    }
+
+    @Override
+    public <T extends Storable> Collection<T> select(String namespace, List<OrderByField> orderByFields) {
+        return executeQuery(namespace, new OracleSelectQuery(namespace, orderByFields));
+    }
+
+    @Override
+    public <T extends Storable> Collection<T> select(final StorableKey storableKey) {
+        OracleSelectQuery oracleSelectQuery = new OracleSelectQuery(storableKey);
+        try {
+            return executeQuery(storableKey.getNameSpace(), oracleSelectQuery);
+        } catch (Exception e) {
+            log.error(String.format("Error while running query : \"%s\"", oracleSelectQuery.getParametrizedSql()), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public <T extends Storable> Collection<T> select(StorableKey storableKey, List<OrderByField> orderByFields) {
+        return executeQuery(storableKey.getNameSpace(), new OracleSelectQuery(storableKey, orderByFields));
+    }
+
+    @Override
+    public Long nextId(String namespace) {
+        OracleSequenceIdQuery oracleSequenceIdQuery = new OracleSequenceIdQuery(namespace, connectionBuilder, queryTimeoutSecs, ORACLE_DATA_TYPE_CONTEXT);
+        return oracleSequenceIdQuery.getNextID();
+    }
+
+    @Override
+    public <T extends Storable> Collection<T> select(SearchQuery searchQuery) {
+        return executeQuery(searchQuery.getNameSpace(), new OracleSelectQuery(searchQuery, storableFactory.create(searchQuery.getNameSpace()).getSchema()));
+    }
+
+    @Override
+    public boolean isColumnInNamespace(String namespace, String columnName) throws SQLException {
+        try (Connection connection = getConnection()) {
+            final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), ORACLE_DATA_TYPE_CONTEXT,
+                    new OracleSelectQuery(namespace)).getMetaData();
+
+            final int columnCount = rsMetadata.getColumnCount();
+
+            for (int i = 1; i <= columnCount; i++) {
+                if (rsMetadata.getColumnName(i).equalsIgnoreCase(columnName)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static OracleExecutor createExecutor(Map<String, Object> jdbcProps) {
+        Util.validateJDBCProperties(jdbcProps, Lists.newArrayList("dataSourceClassName", "dataSource.url"));
+
+        String dataSourceClassName = (String) jdbcProps.get("dataSourceClassName");
+        log.info("data source class: [{}]", dataSourceClassName);
+
+        String jdbcUrl = (String) jdbcProps.get("dataSource.url");
+        log.info("dataSource.url is: [{}] ", jdbcUrl);
+
+        int queryTimeOutInSecs = -1;
+        if (jdbcProps.containsKey("queryTimeoutInSecs")) {
+            queryTimeOutInSecs = (Integer) jdbcProps.get("queryTimeoutInSecs");
+            if (queryTimeOutInSecs < 0) {
+                throw new IllegalArgumentException("queryTimeoutInSecs property can not be negative");
+            }
+        }
+
+        Properties properties = new Properties();
+        properties.putAll(jdbcProps);
+        HikariConfig hikariConfig = new HikariConfig(properties);
+
+        HikariCPConnectionBuilder connectionBuilder = new HikariCPConnectionBuilder(hikariConfig);
+        ExecutionConfig executionConfig = new ExecutionConfig(queryTimeOutInSecs);
+        return new OracleExecutor(executionConfig, connectionBuilder);
+    }
+
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleDeleteQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleDeleteQuery.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query;
+
+import com.hortonworks.registries.storage.StorableKey;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractStorableKeyQuery;
+
+public class OracleDeleteQuery extends AbstractStorableKeyQuery {
+
+    public OracleDeleteQuery(String nameSpace) {
+        super(nameSpace);
+    }
+
+    public OracleDeleteQuery(StorableKey storableKey) {
+        super(storableKey);
+    }
+
+    @Override
+    protected void initParameterizedSql() {
+        sql = "DELETE FROM \"" + tableName + "\" WHERE " + join(getColumnNames(columns, "\"%s\" = ?"), " AND ");
+        log.debug(sql);
+    }
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleInsertQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleInsertQuery.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.Storable;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractStorableSqlQuery;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OracleInsertQuery extends AbstractStorableSqlQuery {
+
+    public OracleInsertQuery(Storable storable) {
+        super(storable);
+    }
+
+    protected Collection<String> getColumnNames(Collection<Schema.Field> columns, final String formatter) {
+        Collection<String> collection = new ArrayList<>();
+        for (Schema.Field field : columns) {
+            if (!field.getName().equalsIgnoreCase("id") || getStorableId() != null) {
+                String fieldName = formatter == null ? field.getName() : String.format(formatter, field.getName());
+                collection.add(fieldName);
+            }
+        }
+        return collection;
+    }
+
+    @Override
+    protected void initParameterizedSql() {
+        Collection<String> columnNames = getColumnNames(columns, "\"%s\"");
+        sql = "INSERT INTO \"" + tableName + "\" ("
+                + join(columnNames, ", ")
+                + ") VALUES ( " + getBindVariables("?,", columnNames.size()) + ")";
+        log.debug(sql);
+    }
+
+    @Override
+    public List<Schema.Field> getColumns() {
+        List<Schema.Field> cols = super.getColumns();
+        if (getStorableId() == null) {
+            return cols.stream()
+                    .filter(f -> !f.getName().equalsIgnoreCase("id"))
+                    .collect(Collectors.toList());
+        }
+        return cols;
+    }
+
+    private Long getStorableId() {
+        try {
+            return getStorable().getId();
+        } catch (UnsupportedOperationException ex) {
+            // ignore
+        }
+        return null;
+    }
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleInsertUpdateDuplicate.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleInsertUpdateDuplicate.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.Storable;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractStorableSqlQuery;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OracleInsertUpdateDuplicate extends AbstractStorableSqlQuery {
+
+    public OracleInsertUpdateDuplicate(Storable storable) {
+        super(storable);
+    }
+
+    @Override
+    protected Collection<String> getColumnNames(Collection<Schema.Field> columns, final String formatter) {
+        Collection<String> collection = new ArrayList<>();
+        for (Schema.Field field : columns) {
+            if (!field.getName().equalsIgnoreCase("id") || getStorableId() != null) {
+                String fieldName = formatter == null ? field.getName() : String.format(formatter, field.getName());
+                collection.add(fieldName);
+            }
+        }
+        return collection;
+    }
+
+    /*
+        Insert or Update query with an example :-
+
+        MERGE INTO employee M
+        USING (SELECT 1 AS id, 'Matt' AS name, '5' AS experience FROM dual) N
+          ON (M.id = N.id)
+        WHEN MATCHED THEN UPDATE
+           SET M.name = N.name ,
+           M.experience = N.experience
+        WHEN NOT MATCHED THEN
+          INSERT( id, name, experience)
+          VALUES(N.id, N.name, N.experience);
+     */
+    @Override
+    protected void initParameterizedSql() {
+        Collection<String> columnNames = getColumnNames(columns, "\"%s\"");
+        List<String> primaryColumnNames = getPrimaryColumns(getStorable(), "%s");
+        List<String> nonPrimaryColumnNames = getNonPrimaryColumns(getStorable(), "%s");
+        sql = " MERGE INTO \"" + tableName + "\" t1 USING " +
+                "( SELECT " + join(getColumnNames(columns, "? as \"%s\""), ",") +
+                " FROM dual ) t2 ON ( " + join(primaryColumnNames.stream().map(pCol ->
+                String.format("t1.\"%s\"=t2.\"%s\"", pCol, pCol)).collect(Collectors.toList()), " AND ") + " )" +
+                ( nonPrimaryColumnNames.size() == 0 ? "" :
+                        " WHEN MATCHED THEN UPDATE SET " + join(nonPrimaryColumnNames.stream().map(col ->
+                                String.format("t1.\"%s\"=t2.\"%s\"", col, col)).collect(Collectors.toList()), " , ") ) +
+                " WHEN NOT MATCHED THEN INSERT (" + join(columnNames, ",") + ") VALUES (" +
+                getBindVariables("?,", columnNames.size()) + ")";
+        log.debug(sql);
+    }
+
+    @Override
+    public List<Schema.Field> getColumns() {
+        List<Schema.Field> cols = super.getColumns();
+        if (getStorableId() == null) {
+            return cols.stream()
+                    .filter(f -> !f.getName().equalsIgnoreCase("id"))
+                    .collect(Collectors.toList());
+        }
+        return cols;
+    }
+
+    private Long getStorableId() {
+        try {
+            return getStorable().getId();
+        } catch (UnsupportedOperationException ex) {
+            // ignore
+        }
+        return null;
+    }
+
+    private List<String> getPrimaryColumns(Storable storable, final String formatter) {
+        return storable.getPrimaryKey().getFieldsToVal().keySet().stream().map(
+                colField -> String.format(formatter, colField.getName())).collect(Collectors.toList());
+    }
+
+    private List<String> getNonPrimaryColumns(Storable storable, final String formatter) {
+        Set<String> primaryKeySet = new HashSet();
+        primaryKeySet.addAll(getPrimaryColumns(storable, "%s"));
+        Collection<String> columnNames = getColumnNames(columns, "%s");
+        return columnNames.stream().filter(colField -> !primaryKeySet.contains(colField)).collect(Collectors.toList());
+    }
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleSelectQuery.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.OrderByField;
+import com.hortonworks.registries.storage.StorableKey;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.exception.OracleQueryException;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSelectQuery;
+import com.hortonworks.registries.storage.search.SearchQuery;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class OracleSelectQuery extends AbstractSelectQuery {
+
+    public OracleSelectQuery(String nameSpace) {
+        super(nameSpace);
+    }
+
+    public OracleSelectQuery(StorableKey storableKey) {
+        super(storableKey);
+    }
+
+    public OracleSelectQuery(String nameSpace, List<OrderByField> orderByFields) {
+        super(nameSpace, orderByFields);
+    }
+
+    public OracleSelectQuery(StorableKey storableKey, List<OrderByField> orderByFields) {
+        super(storableKey, orderByFields);
+    }
+
+    public OracleSelectQuery(SearchQuery searchQuery, Schema schema) {
+        super(searchQuery, schema);
+    }
+
+    @Override
+    protected String fieldEncloser() {
+        return "\"";
+    }
+
+    @Override
+    protected String tableNameEncloser() {
+        return "\"";
+    }
+
+    @Override
+    protected void initParameterizedSql() {
+        sql = "SELECT * FROM " + tableNameEncloser() + tableName + tableNameEncloser();
+        if (columns != null) {
+            List<String> whereClauseColumns = new LinkedList<>();
+            for (Map.Entry<Schema.Field, Object> columnKeyValue : primaryKey.getFieldsToVal().entrySet()) {
+                if (columnKeyValue.getKey().getType() == Schema.Type.STRING) {
+                    String stringValue = (String) columnKeyValue.getValue();
+                    if ((stringValue).length() > 4000) {
+                        throw new OracleQueryException(String.format("Column \"%s\" of the table \"%s\" is compared against a value \"%s\", " +
+                                        "which is greater than 4k characters",
+                                columnKeyValue.getKey().getName(), tableName, stringValue));
+                    } else
+                        whereClauseColumns.add(String.format(" to_char(\"%s\") = ?", columnKeyValue.getKey().getName()));
+                } else {
+                    whereClauseColumns.add(String.format(" \"%s\" = ?", columnKeyValue.getKey().getName()));
+                }
+            }
+            sql += " WHERE " + join(whereClauseColumns, " AND ");
+        }
+        log.debug(sql);
+    }
+
+    protected void addOrderByFieldsToParameterizedSql() {
+        if (orderByFields != null && !orderByFields.isEmpty()) {
+            sql += join(orderByFields.stream()
+                    .map(x -> " ORDER BY " + fieldEncloser() + x.getFieldName() + fieldEncloser() + " " + (x.isDescending() ? "DESC" : "ASC"))
+                    .collect(Collectors.toList()), ",");
+        }
+
+        log.debug("SQL after adding order by clause: [{}]", sql);
+    }
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleSequenceIdQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleSequenceIdQuery.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query;
+
+import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
+import com.hortonworks.registries.storage.impl.jdbc.connection.ConnectionBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.statement.OracleDataTypeContext;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSqlQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class OracleSequenceIdQuery {
+    private static final Logger log = LoggerFactory.getLogger(OracleSequenceIdQuery.class);
+    private static final String nextValueFunction = "nextval";
+    private static final String SEQUENCE_SUFFIX = "__sequence";
+    private String namespace;
+    private ConnectionBuilder connectionBuilder;
+    private int queryTimeoutSecs;
+    private final OracleDataTypeContext oracleDataTypeContext;
+
+    public OracleSequenceIdQuery(String namespace, ConnectionBuilder connectionBuilder, int queryTimeoutSecs, OracleDataTypeContext oracleDataTypeContext) {
+        this.namespace = namespace;
+        this.connectionBuilder = connectionBuilder;
+        this.queryTimeoutSecs = queryTimeoutSecs;
+        this.oracleDataTypeContext = oracleDataTypeContext;
+    }
+
+    public Long getNextID() {
+
+        OracleSqlQuery nextValueQuery = new OracleSqlQuery(String.format("SELECT %s%s.%s from DUAL", namespace, SEQUENCE_SUFFIX, nextValueFunction));
+        Long nextId = 0l;
+
+        try (Connection connection = connectionBuilder.getConnection()) {
+            ResultSet selectResultSet = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), oracleDataTypeContext, nextValueQuery).getPreparedStatement(nextValueQuery).executeQuery();
+            if (selectResultSet.next()) {
+                nextId = selectResultSet.getLong(nextValueFunction);
+            } else {
+                throw new RuntimeException("No sequence-id created for the current sequence of [" + namespace + "]");
+            }
+            log.debug("Generated sequence id [{}] for [{}]", nextId, namespace);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+
+        return nextId;
+    }
+
+    static class OracleSqlQuery extends AbstractSqlQuery {
+
+        public OracleSqlQuery(String sql) {
+            this.sql = sql;
+        }
+
+        @Override
+        protected void initParameterizedSql() {
+        }
+    }
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/statement/OracleDataTypeContext.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/statement/OracleDataTypeContext.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.statement;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.exception.StorageException;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.StorageDataTypeContext;
+import com.hortonworks.registries.storage.impl.jdbc.util.Util;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.sql.Blob;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OracleDataTypeContext implements StorageDataTypeContext {
+
+    private static final Logger log = LoggerFactory.getLogger(OracleDataTypeContext.class);
+    private static final String EMPTY_STRING_PLACEHOLDER = "<EMPTY>";
+
+    @Override
+    public void setPreparedStatementParams(PreparedStatement preparedStatement,
+                                           Schema.Type type, int index, Object val) throws SQLException {
+        if (val == null) {
+            preparedStatement.setNull(index, getSqlType(type));
+            return;
+        }
+
+        switch (type) {
+            case BOOLEAN:
+                preparedStatement.setBoolean(index, (Boolean) val);
+                break;
+            case BYTE:
+                preparedStatement.setByte(index, (Byte) val);
+                break;
+            case SHORT:
+                preparedStatement.setShort(index, (Short) val);
+                break;
+            case INTEGER:
+                preparedStatement.setInt(index, (Integer) val);
+                break;
+            case LONG:
+                preparedStatement.setLong(index, (Long) val);
+                break;
+            case FLOAT:
+                preparedStatement.setFloat(index, (Float) val);
+                break;
+            case DOUBLE:
+                preparedStatement.setDouble(index, (Double) val);
+                break;
+            case STRING:
+                String stringValue = (String) val;
+                if (StringUtils.isEmpty(stringValue))
+                    preparedStatement.setString(index, EMPTY_STRING_PLACEHOLDER);
+                else
+                    preparedStatement.setString(index, stringValue);
+                break;
+            case BINARY:
+                preparedStatement.setBytes(index, (byte[]) val);
+                break;
+            case BLOB:
+                preparedStatement.setBinaryStream(index, (InputStream) val);
+                break;
+            case NESTED:
+            case ARRAY:
+                preparedStatement.setObject(index, val);    //TODO check this
+                break;
+        }
+    }
+
+    @Override
+    public Map<String, Object> getMapWithRowContents(ResultSet resultSet, ResultSetMetaData rsMetadata) throws SQLException {
+        final Map<String, Object> map = new HashMap<>();
+        final int columnCount = rsMetadata.getColumnCount();
+
+        for (int i = 1; i <= columnCount; i++) {
+            final String columnLabel = rsMetadata.getColumnLabel(i);
+            final int columnType = rsMetadata.getColumnType(i);
+            final int columnPrecision = rsMetadata.getPrecision(i);
+            final Class columnJavaType = Util.getJavaType(columnType, columnPrecision);
+
+            if (columnJavaType.equals(String.class)) {
+                String stringValue = resultSet.getString(columnLabel);
+                if (stringValue != null && stringValue.equals(EMPTY_STRING_PLACEHOLDER))
+                    map.put(columnLabel, "");
+                else
+                    map.put(columnLabel, stringValue);
+            } else if (columnJavaType.equals(Integer.class)) {
+                map.put(columnLabel, resultSet.getInt(columnLabel));
+            } else if (columnJavaType.equals(Double.class)) {
+                map.put(columnLabel, resultSet.getDouble(columnLabel));
+            } else if (columnJavaType.equals(Float.class)) {
+                map.put(columnLabel, resultSet.getFloat(columnLabel));
+            } else if (columnJavaType.equals(Byte.class)) {
+                map.put(columnLabel, resultSet.getByte(columnLabel));
+            } else if (columnJavaType.equals(Short.class)) {
+                map.put(columnLabel, resultSet.getShort(columnLabel));
+            } else if (columnJavaType.equals(Boolean.class)) {
+                map.put(columnLabel, resultSet.getBoolean(columnLabel));
+            } else if (columnJavaType.equals(byte[].class)) {
+                map.put(columnLabel, resultSet.getBytes(columnLabel));
+            } else if (columnJavaType.equals(Long.class)) {
+                map.put(columnLabel, resultSet.getLong(columnLabel));
+            } else if (columnJavaType.equals(Date.class)) {
+                map.put(columnLabel, resultSet.getDate(columnLabel));
+            } else if (columnJavaType.equals(Time.class)) {
+                map.put(columnLabel, resultSet.getTime(columnLabel));
+            } else if (columnJavaType.equals(Timestamp.class)) {
+                map.put(columnLabel, resultSet.getTimestamp(columnLabel));
+            } else if (columnJavaType.equals(InputStream.class)) {
+                Blob blob = resultSet.getBlob(columnLabel);
+                map.put(columnLabel, blob == null ? null : blob.getBinaryStream());
+            } else {
+                throw new StorageException("type =  [" + columnType + "] for column [" + columnLabel + "] not supported.");
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Row for ResultSet [{}] with metadata [{}] generated Map [{}]", resultSet, rsMetadata, map);
+        }
+        return map;
+    }
+
+    private int getSqlType(Schema.Type type) {
+        switch (type) {
+            case BOOLEAN:
+                return Types.BOOLEAN;
+            case BYTE:
+                return Types.TINYINT;
+            case SHORT:
+                return Types.SMALLINT;
+            case INTEGER:
+                return Types.INTEGER;
+            case LONG:
+                return Types.BIGINT;
+            case FLOAT:
+                return Types.REAL;
+            case DOUBLE:
+                return Types.DOUBLE;
+            case STRING:
+                // it might be a VARCHAR or LONGVARCHAR
+                return Types.VARCHAR;
+            case BINARY:
+                // it might be a VARBINARY or LONGVARBINARY
+                return Types.VARBINARY;
+            case NESTED:
+            case ARRAY:
+                return Types.JAVA_OBJECT;
+            default:
+                throw new IllegalArgumentException("Not supported type: " + type);
+        }
+    }
+
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/query/PhoenixSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/query/PhoenixSelectQuery.java
@@ -49,6 +49,11 @@ public class PhoenixSelectQuery extends AbstractSelectQuery {
     }
 
     @Override
+    protected String tableNameEncloser() {
+        return "\"";
+    }
+
+    @Override
     protected void addOrderByFieldsToParameterizedSql() {
         if (orderByFields != null && !orderByFields.isEmpty()) {
             sql += join(orderByFields.stream()

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/query/PhoenixSequenceIdQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/phoenix/query/PhoenixSequenceIdQuery.java
@@ -18,7 +18,9 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.phoenix.query;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
 import com.hortonworks.registries.storage.impl.jdbc.connection.ConnectionBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSqlQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.DefaultStorageDataTypeContext;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.StorageDataTypeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +40,7 @@ public class PhoenixSequenceIdQuery {
     private static final String SEQUENCE_TABLE = "sequence_table";
     private final String namespace;
     private final ConnectionBuilder connectionBuilder;
+    private static final StorageDataTypeContext STORAGE_DATA_TYPE_CONTEXT = new DefaultStorageDataTypeContext();
     private final int queryTimeoutSecs;
 
     public PhoenixSequenceIdQuery(String namespace, ConnectionBuilder connectionBuilder, int queryTimeoutSecs) {
@@ -60,17 +63,17 @@ public class PhoenixSequenceIdQuery {
         PhoenixSqlQuery deleteQuery = new PhoenixSqlQuery("DELETE FROM " + SEQUENCE_TABLE + " WHERE \"id\"='" + uuid + "'");
 
         try (Connection connection = connectionBuilder.getConnection()) {
-            int upsertResult = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), updateQuery).getPreparedStatement(updateQuery).executeUpdate();
+            int upsertResult = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), STORAGE_DATA_TYPE_CONTEXT, updateQuery).getPreparedStatement(updateQuery).executeUpdate();
             log.debug("Query [{}] is executed and returns result with [{}]", updateQuery, upsertResult);
 
-            ResultSet selectResultSet = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), selectQuery).getPreparedStatement(selectQuery).executeQuery();
+            ResultSet selectResultSet = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), STORAGE_DATA_TYPE_CONTEXT, selectQuery).getPreparedStatement(selectQuery).executeQuery();
             if (selectResultSet.next()) {
                 nextId = selectResultSet.getLong(namespace);
             } else {
                 throw new RuntimeException("No sequence-id created for the current sequence of [" + namespace + "]");
             }
             log.debug("Generated sequence id [{}] for [{}]", nextId, namespace);
-            int deleteResult = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), deleteQuery).getPreparedStatement(deleteQuery).executeUpdate();
+            int deleteResult = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), STORAGE_DATA_TYPE_CONTEXT, deleteQuery).getPreparedStatement(deleteQuery).executeUpdate();
             if (deleteResult == 0) {
                 log.error("Could not delete entry in " + SEQUENCE_TABLE + " for value [{}]", namespace, uuid);
             } else {

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/query/PostgresqlSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/query/PostgresqlSelectQuery.java
@@ -63,6 +63,11 @@ public class PostgresqlSelectQuery extends AbstractSelectQuery {
     }
 
     @Override
+    protected String tableNameEncloser() {
+        return "\"";
+    }
+
+    @Override
     protected void addOrderByFieldsToParameterizedSql() {
         if (orderByFields != null && !orderByFields.isEmpty()) {
             sql += join(orderByFields.stream()

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/AbstractQueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/AbstractQueryExecutor.java
@@ -26,25 +26,21 @@ import com.hortonworks.registries.storage.exception.StorageException;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
 import com.hortonworks.registries.storage.impl.jdbc.connection.ConnectionBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlDeleteQuery;
-import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlInsertQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlSelectQuery;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.DefaultStorageDataTypeContext;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
-import com.hortonworks.registries.storage.impl.jdbc.util.Util;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.StorageDataTypeContext;
 
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -61,19 +57,29 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
     protected final int queryTimeoutSecs;
     protected final ConnectionBuilder connectionBuilder;
     protected final List<Connection> activeConnections;
+    protected final StorageDataTypeContext storageDataTypeContext;
 
     private final Cache<SqlQuery, PreparedStatementBuilder> cache;
     protected StorableFactory storableFactory;
 
     public AbstractQueryExecutor(ExecutionConfig config, ConnectionBuilder connectionBuilder) {
-        this(config, connectionBuilder, null);
+        this(config, connectionBuilder, null, new DefaultStorageDataTypeContext());
     }
 
     public AbstractQueryExecutor(ExecutionConfig config, ConnectionBuilder connectionBuilder, CacheBuilder<SqlQuery, PreparedStatementBuilder> cacheBuilder) {
+        this(config, connectionBuilder, cacheBuilder, new DefaultStorageDataTypeContext());
+    }
+
+    public AbstractQueryExecutor(ExecutionConfig config, ConnectionBuilder connectionBuilder, StorageDataTypeContext storageDataTypeContext) {
+        this(config, connectionBuilder, null, storageDataTypeContext);
+    }
+
+    public AbstractQueryExecutor(ExecutionConfig config, ConnectionBuilder connectionBuilder, CacheBuilder<SqlQuery, PreparedStatementBuilder> cacheBuilder, StorageDataTypeContext storageDataTypeContext) {
         this.connectionBuilder = connectionBuilder;
         this.config = config;
         cache = cacheBuilder != null ? buildCache(cacheBuilder) : null;
         this.queryTimeoutSecs = config.getQueryTimeoutSecs();
+        this.storageDataTypeContext = storageDataTypeContext;
         activeConnections = Collections.synchronizedList(new ArrayList<Connection>());
     }
 
@@ -175,6 +181,26 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
         this.storableFactory = storableFactory;
     }
 
+    @Override
+    public boolean isColumnInNamespace(String namespace, String columnName) throws SQLException {
+        try(Connection connection = getConnection()) {
+            final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), storageDataTypeContext,
+                    new SqlSelectQuery(namespace)).getMetaData();
+
+            final int columnCount = rsMetadata.getColumnCount();
+
+            for (int i = 1; i <= columnCount; i++) {
+                if (rsMetadata.getColumnName(i).equalsIgnoreCase(columnName)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
 
     // =============== Private helper Methods ===============
 
@@ -264,7 +290,7 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
                 preparedStatementBuilder = cache.get(sqlBuilder, new PreparedStatementBuilderCallable(sqlBuilder, false));
             } else {
                 connection = getConnection();
-                preparedStatementBuilder = PreparedStatementBuilder.of(connection, config, sqlBuilder);
+                preparedStatementBuilder = PreparedStatementBuilder.of(connection, config, storageDataTypeContext, sqlBuilder);
             }
             return preparedStatementBuilder.getPreparedStatement(sqlBuilder);
         }
@@ -276,7 +302,7 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
                 preparedStatementBuilder = cache.get(sqlBuilder, new PreparedStatementBuilderCallable(sqlBuilder, true));
             } else {
                 connection = getConnection();
-                preparedStatementBuilder = PreparedStatementBuilder.supportReturnGeneratedKeys(connection, config, sqlBuilder);
+                preparedStatementBuilder = PreparedStatementBuilder.supportReturnGeneratedKeys(connection, config, storageDataTypeContext, sqlBuilder);
             }
             return preparedStatementBuilder.getPreparedStatement(sqlBuilder);
         }
@@ -304,9 +330,9 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
                 // opens a new connection which remains open for as long as this entry is in the cache
                 final PreparedStatementBuilder preparedStatementBuilder;
                 if (returnGeneratedKeys) {
-                    preparedStatementBuilder = PreparedStatementBuilder.supportReturnGeneratedKeys(getConnection(), config, sqlBuilder);
+                    preparedStatementBuilder = PreparedStatementBuilder.supportReturnGeneratedKeys(getConnection(), config, storageDataTypeContext, sqlBuilder);
                 } else {
-                    preparedStatementBuilder = PreparedStatementBuilder.of(getConnection(), config, sqlBuilder);
+                    preparedStatementBuilder = PreparedStatementBuilder.of(getConnection(), config, storageDataTypeContext, sqlBuilder);
                 }
                 log.debug("Loading cache with [key: {}, val: {}]", sqlBuilder, preparedStatementBuilder);
                 return preparedStatementBuilder;
@@ -339,7 +365,7 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
                     maps = new LinkedList<>();
                     ResultSetMetaData rsMetadata = resultSet.getMetaData();
                     do {
-                        Map<String, Object> map = newMapWithRowContents(resultSet, rsMetadata);
+                        Map<String, Object> map = storageDataTypeContext.getMapWithRowContents(resultSet, rsMetadata);
                         maps.add(map);
                     } while(resultSet.next());
                 }
@@ -351,49 +377,6 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
 
         private <T extends Storable> T newStorableInstance(String nameSpace) {
             return (T) storableFactory.create(nameSpace);
-        }
-
-        private Map<String, Object> newMapWithRowContents(ResultSet resultSet, ResultSetMetaData rsMetadata) throws SQLException {
-            final Map<String, Object> map = new HashMap<>();
-            final int columnCount = rsMetadata.getColumnCount();
-
-            for (int i = 1 ; i <= columnCount; i++) {
-                final String columnLabel = rsMetadata.getColumnLabel(i);
-                final int columnType = rsMetadata.getColumnType(i);
-                final Class columnJavaType = Util.getJavaType(columnType);
-
-                if (columnJavaType.equals(String.class)) {
-                    map.put(columnLabel, resultSet.getString(columnLabel));
-                } else if (columnJavaType.equals(Byte.class)) {
-                    map.put(columnLabel, resultSet.getByte(columnLabel));
-                } else if (columnJavaType.equals(Integer.class)) {
-                    map.put(columnLabel, resultSet.getInt(columnLabel));
-                } else if (columnJavaType.equals(Double.class)) {
-                    map.put(columnLabel, resultSet.getDouble(columnLabel));
-                } else if (columnJavaType.equals(Float.class)) {
-                    map.put(columnLabel, resultSet.getFloat(columnLabel));
-                } else if (columnJavaType.equals(Short.class)) {
-                    map.put(columnLabel, resultSet.getShort(columnLabel));
-                } else if (columnJavaType.equals(Boolean.class)) {
-                    map.put(columnLabel, resultSet.getBoolean(columnLabel));
-                } else if (columnJavaType.equals(byte[].class)) {
-                    map.put(columnLabel, resultSet.getBytes(columnLabel));
-                } else if (columnJavaType.equals(Long.class)) {
-                    map.put(columnLabel, resultSet.getLong(columnLabel));
-                } else if (columnJavaType.equals(Date.class)) {
-                    map.put(columnLabel, resultSet.getDate(columnLabel));
-                } else if (columnJavaType.equals(Time.class)) {
-                    map.put(columnLabel, resultSet.getTime(columnLabel));
-                } else if (columnJavaType.equals(Timestamp.class)) {
-                    map.put(columnLabel, resultSet.getTimestamp(columnLabel));
-                } else {
-                    throw new StorageException("type =  [" + columnType + "] for column [" + columnLabel + "] not supported.");
-                }
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("Row for ResultSet [{}] with metadata [{}] generated Map [{}]", resultSet, rsMetadata, map);
-            }
-            return map;
         }
     }
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
@@ -105,4 +106,9 @@ public interface QueryExecutor {
 
     //todo unify all other select methods with this method as they are kind of special cases of SearchQuery
     <T extends Storable> Collection<T> select(SearchQuery searchQuery);
+
+    /**
+     * @return true if a table has the columnName else false
+     */
+    boolean isColumnInNamespace(String namespace, String columnName) throws SQLException;
 }

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSelectQuery.java
@@ -67,7 +67,7 @@ public abstract class AbstractSelectQuery extends AbstractStorableKeyQuery {
     }
 
     protected void buildSqlWithSearchQuery(SearchQuery searchQuery, Schema schema) {
-        sql = "SELECT * FROM " + tableName;
+        sql = "SELECT * FROM " + tableNameEncloser() + tableName + tableNameEncloser() ;
 
         WhereClause whereClause = searchQuery.getWhereClause();
         Map<Schema.Field, Object> fieldsToValues = new HashMap<>();
@@ -112,6 +112,8 @@ public abstract class AbstractSelectQuery extends AbstractStorableKeyQuery {
     }
 
     protected abstract String fieldEncloser();
+
+    protected abstract String tableNameEncloser();
 
     private String generateClauseString(Predicate predicate, Map<Schema.Field, Object> fieldsToValues, Schema schema) {
         if(predicate == null) {

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/MetadataHelper.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/MetadataHelper.java
@@ -18,6 +18,7 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.sql.query;
 
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.StorageDataTypeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,8 +32,8 @@ import java.sql.SQLException;
 public class MetadataHelper {
     private static final Logger log = LoggerFactory.getLogger(MetadataHelper.class);
 
-    public static boolean isAutoIncrement(Connection connection, String namespace, int queryTimeoutSecs) throws SQLException {
-        final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs),
+    public static boolean isAutoIncrement(Connection connection, String namespace, int queryTimeoutSecs, StorageDataTypeContext storageDataTypeContext) throws SQLException {
+        final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), storageDataTypeContext,
                 new SqlSelectQuery(namespace)).getMetaData();
 
         final int columnCount = rsMetadata.getColumnCount();
@@ -44,19 +45,4 @@ public class MetadataHelper {
         }
         return false;
     }
-
-    public static boolean isColumnInNamespace(Connection connection, int queryTimeoutSecs, String namespace, String columnName) throws SQLException {
-        final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs),
-                new SqlSelectQuery(namespace)).getMetaData();
-
-        final int columnCount = rsMetadata.getColumnCount();
-
-        for (int i = 1; i <= columnCount; i++) {
-            if (rsMetadata.getColumnName(i).equalsIgnoreCase(columnName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 }

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/SqlSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/SqlSelectQuery.java
@@ -34,6 +34,11 @@ public class SqlSelectQuery extends AbstractSelectQuery {
     }
 
     @Override
+    protected String tableNameEncloser() {
+        return "";
+    }
+
+    @Override
     protected void addOrderByFieldsToParameterizedSql() {
         if (orderByFields != null && !orderByFields.isEmpty()) {
             sql += join(orderByFields.stream()

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/statement/DefaultStorageDataTypeContext.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/statement/DefaultStorageDataTypeContext.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement;
+
+import com.hortonworks.registries.common.Schema;
+import com.hortonworks.registries.storage.exception.StorageException;
+import com.hortonworks.registries.storage.impl.jdbc.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultStorageDataTypeContext implements StorageDataTypeContext{
+    private static final Logger log = LoggerFactory.getLogger(DefaultStorageDataTypeContext.class);
+
+    @Override
+    public void setPreparedStatementParams(PreparedStatement preparedStatement,
+                                           Schema.Type type, int index, Object val) throws SQLException {
+        if (val == null) {
+            preparedStatement.setNull(index, getSqlType(type));
+            return;
+        }
+
+        switch (type) {
+            case BOOLEAN:
+                preparedStatement.setBoolean(index, (Boolean) val);
+                break;
+            case BYTE:
+                preparedStatement.setByte(index, (Byte) val);
+                break;
+            case SHORT:
+                preparedStatement.setShort(index, (Short) val);
+                break;
+            case INTEGER:
+                preparedStatement.setInt(index, (Integer) val);
+                break;
+            case LONG:
+                preparedStatement.setLong(index, (Long) val);
+                break;
+            case FLOAT:
+                preparedStatement.setFloat(index, (Float) val);
+                break;
+            case DOUBLE:
+                preparedStatement.setDouble(index, (Double) val);
+                break;
+            case STRING:
+                preparedStatement.setString(index, (String) val);
+                break;
+            case BINARY:
+                preparedStatement.setBytes(index, (byte[]) val);
+                break;
+            case BLOB:
+                preparedStatement.setBinaryStream(index, (InputStream) val);
+                break;
+            case NESTED:
+            case ARRAY:
+                preparedStatement.setObject(index, val);    //TODO check this
+                break;
+        }
+    }
+
+    @Override
+    public Map<String, Object> getMapWithRowContents(ResultSet resultSet, ResultSetMetaData rsMetadata) throws SQLException {
+        final Map<String, Object> map = new HashMap<>();
+        final int columnCount = rsMetadata.getColumnCount();
+
+        for (int i = 1 ; i <= columnCount; i++) {
+            final String columnLabel = rsMetadata.getColumnLabel(i);
+            final int columnType = rsMetadata.getColumnType(i);
+            final int columnPrecision = rsMetadata.getPrecision(i);
+            final Class columnJavaType = Util.getJavaType(columnType, columnPrecision);
+
+            if (columnJavaType.equals(String.class)) {
+                map.put(columnLabel, resultSet.getString(columnLabel));
+            } else if (columnJavaType.equals(Byte.class)) {
+                map.put(columnLabel, resultSet.getByte(columnLabel));
+            } else if (columnJavaType.equals(Integer.class)) {
+                map.put(columnLabel, resultSet.getInt(columnLabel));
+            } else if (columnJavaType.equals(Double.class)) {
+                map.put(columnLabel, resultSet.getDouble(columnLabel));
+            } else if (columnJavaType.equals(Float.class)) {
+                map.put(columnLabel, resultSet.getFloat(columnLabel));
+            } else if (columnJavaType.equals(Short.class)) {
+                map.put(columnLabel, resultSet.getShort(columnLabel));
+            } else if (columnJavaType.equals(Boolean.class)) {
+                map.put(columnLabel, resultSet.getBoolean(columnLabel));
+            } else if (columnJavaType.equals(byte[].class)) {
+                map.put(columnLabel, resultSet.getBytes(columnLabel));
+            } else if (columnJavaType.equals(Long.class)) {
+                map.put(columnLabel, resultSet.getLong(columnLabel));
+            } else if (columnJavaType.equals(Date.class)) {
+                map.put(columnLabel, resultSet.getDate(columnLabel));
+            } else if (columnJavaType.equals(Time.class)) {
+                map.put(columnLabel, resultSet.getTime(columnLabel));
+            } else if (columnJavaType.equals(Timestamp.class)) {
+                map.put(columnLabel, resultSet.getTimestamp(columnLabel));
+            } else {
+                throw new StorageException("type =  [" + columnType + "] for column [" + columnLabel + "] not supported.");
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Row for ResultSet [{}] with metadata [{}] generated Map [{}]", resultSet, rsMetadata, map);
+        }
+        return map;
+    }
+
+    private int getSqlType(Schema.Type type) {
+        switch (type) {
+            case BOOLEAN:
+                return Types.BOOLEAN;
+            case BYTE:
+                return Types.TINYINT;
+            case SHORT:
+                return Types.SMALLINT;
+            case INTEGER:
+                return Types.INTEGER;
+            case LONG:
+                return Types.BIGINT;
+            case FLOAT:
+                return Types.REAL;
+            case DOUBLE:
+                return Types.DOUBLE;
+            case STRING:
+                // it might be a VARCHAR or LONGVARCHAR
+                return Types.VARCHAR;
+            case BINARY:
+                // it might be a VARBINARY or LONGVARBINARY
+                return Types.VARBINARY;
+            case NESTED:
+            case ARRAY:
+                return Types.JAVA_OBJECT;
+            default:
+                throw new IllegalArgumentException("Not supported type: " + type);
+        }
+    }
+
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/statement/StorageDataTypeContext.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/statement/StorageDataTypeContext.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement;
+
+import com.hortonworks.registries.common.Schema;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Map;
+
+public interface StorageDataTypeContext {
+
+    /**
+     * Given a prepared statement, maps each column's Java type to its underlying SQL type and set its value accordingly
+     */
+    void setPreparedStatementParams(PreparedStatement preparedStatement, Schema.Type type, int index, Object val) throws SQLException;
+
+    /**
+     * Given a resultSet extracts the next row and returns it as a Map
+     */
+
+    Map<String, Object> getMapWithRowContents(ResultSet resultSet, ResultSetMetaData rsMetadata) throws SQLException;
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/util/Util.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/util/Util.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Hortonworks.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.storage.impl.jdbc.util;
 
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.sql.Date;
 import java.sql.Time;
@@ -38,7 +39,7 @@ public class Util {
         throw new RuntimeException("Unknown sqlType " + sqlType);
     }
 
-    public static Class getJavaType(int sqlType) {
+    public static Class getJavaType(int sqlType, int precision) {
         switch (sqlType) {
             case Types.CHAR:
             case Types.VARCHAR:
@@ -47,8 +48,10 @@ public class Util {
                 return String.class;
             case Types.BINARY:
             case Types.VARBINARY:
-            case Types.LONGVARBINARY:
                 return byte[].class;
+            case Types.BLOB:
+            case Types.LONGVARBINARY:
+                return InputStream.class;
             case Types.BIT:
                 return Boolean.class;
             case Types.TINYINT:
@@ -70,6 +73,17 @@ public class Util {
                 return Time.class;
             case Types.TIMESTAMP:
                 return Timestamp.class;
+            case Types.NUMERIC:
+                switch (precision) {
+                    case 1:
+                        return Boolean.class;
+                    case 3:
+                        return Byte.class;
+                    case 10:
+                        return Integer.class;
+                    default:
+                        return Long.class;
+                }
             default:
                 throw new RuntimeException("We do not support tables with SqlType: " + getSqlTypeName(sqlType));
         }


### PR DESCRIPTION
More info on the pull request : 
  * I have used the following conversions (MySQL -> Oracle)
          TEXT -> if data < 4KB then VARCHAR2(4000) else CLOB
          TINYINT -> NUMERIC(3,0)
          LONG -> NUMERIC(19,0)
          INTEGER -> NUMERIC(10,0)
          BOOLEAN -> NUMERIC(1,0)
  * I haven't used Oracle equivalent of "ON UPDATE CASCADE" in migration scripts as Oracle doesn't have any out of box support for this and I couldn't find any use case in SR.
  * The user has to manually copy the Oracle JDBC driver jar to /bootstrap/lib directory, as it is not straightforward to download the jar from Oracle's website.
