### PR TITLE
ISSUE-263 Improve the commit process

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -134,41 +134,38 @@ A summary with the contents of the patch is optional but strongly encouraged if 
 
 <a name="merge-pull-request"></a>
 
-### Merge a pull request or patch
+### Merge a pull request
 
-To pull in a merge request you should generally follow the command line instructions sent out by GitHub.
+You can utilize merge script to merge a pull request. There're some tasks prior to use the script. 
 
-1. Create remote repo called upstream with Registry [repo](https://github.com/hortonworks/registry.git)
+#### CI Build
+Registry is integrated with travis CI. The status of the build for the pending pull request will be reflected in the PR itself. You must see "The Travis CI build passed" in the pull request before merging it.
 
-        $ git remote add upstream https://github.com/hortonworks/registry.git
-        $ git fetch upstream
-        
-2. Create a local branch for integrating and testing the pull request.  You may want to name the branch according to 
-   Registry Issue associated with the pull request (example: `ISSUE-1234`).
+#### Preparation
 
-        $ git checkout -b <local_test_branch>  upstream/master # e.g. git checkout -b ISSUE-1234
+1. Add Github mirror git repo to remote named `pull-repo`. You can set `PR_REMOTE_NAME` in system environment to use another name.
 
-3. Merge the pull request into your local test branch.
+```
+$ git remote add pull-repo https://github.com/hortonworks/registry.git
+```
 
-        $ git pull <remote_repo_url> <remote_branch>
+2. Add git repo for push to remote named `push-repo`. You can set `PUSH_REMOTE_NAME` in system environment to use another name.
 
-4.  Assuming that the pull request merges without any conflicts:
+```
+$ git remote add push-repo <push repository git url>
+```
 
-5. Run any sanity tests that you think are needed as mentioned in [build the code and run the tests](#build-the-code-and-run-the-tests).
+#### How to use merge script
 
-6. Once you are confident that everything is ok, you can merge your local test branch into your local `master` branch,
-   and push the changes back to remote repo.
+All merges should be done using the dev/merge_registry_pr.py script, which squashes the pull request’s changes into one commit. 
+The script is fairly self explanatory and walks you through steps and options interactively.
 
-        # Pull request looks ok, change log was updated, etc.  We are ready for pushing.
-        $ git checkout master
-        $ git merge <local_test_branch>  # e.g. git merge ISSUE-1234
+Please note that the script prompts for merger after squashed commit is made. Merger can then run the build and do the manual test before pushing, 
+but in normal it is encouraged to see the CI build success on PR before merging the PR, so unless merger wants to do some manual tests, 
+it is fine to do the push immediately.
 
-        # At this point our local master branch is ready, so now we will push the changes
-        # to the official repo.  
-        $ git push origin  HEAD:refs/heads/master 
+After the PR is merged, in normal only the PR will be closed. You may need to handle associated issue manually. 
 
-7. The last step is updating the corresponding Github issue with respective resolution.
-   
 <a name="building"></a>
 
 # Build the code and run the tests

--- a/dev-tools/merge_registry_pr.py
+++ b/dev-tools/merge_registry_pr.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Utility for creating well-formed pull request merges and pushing them to Registry.
+#   usage: ./merge_registry_pr.py    (see config env vars below)
+#
+# This script is inspired by Spark merge script and also borrow some codes from Kafka.
+#
+# This utility assumes you already have a local Registry git folder and that you
+# have added remotes corresponding to both (i) the pull repository (which pull requests are available)
+# and (ii) the push repository.
+
+import json
+import os
+import subprocess
+import sys
+import urllib2
+
+# Location of your Registry git development area
+REGISTRY_HOME = os.environ.get("REGISTRY_HOME", os.getcwd())
+# Remote name which points to pull repository
+PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "pull-repo")
+# Remote name which points to push repository
+PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "push-repo")
+# OAuth key used for issuing requests against the GitHub API. If this is not defined, then requests
+# will be unauthenticated. You should only need to configure this if you find yourself regularly
+# exceeding your IP's unauthenticated request rate limit. You can create an OAuth key at
+# https://github.com/settings/tokens. This script only requires the "public_repo" scope.
+GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY")
+
+
+GITHUB_BASE = "https://github.com/hortonworks/registry/pull"
+GITHUB_API_BASE = "https://api.github.com/repos/hortonworks/registry"
+# Prefix added to temporary branches
+BRANCH_PREFIX = "PR_TOOL"
+
+
+def get_json(url):
+    try:
+        request = urllib2.Request(url)
+        if GITHUB_OAUTH_KEY:
+            request.add_header('Authorization', 'token %s' % GITHUB_OAUTH_KEY)
+        return json.load(urllib2.urlopen(request))
+    except urllib2.HTTPError as e:
+        if "X-RateLimit-Remaining" in e.headers and e.headers["X-RateLimit-Remaining"] == '0':
+            message = "Exceeded the GitHub API rate limit; see the instructions in " +\
+                  "dev/merge_registry_pr.py to configure an OAuth token for making authenticated " +\
+                  "GitHub requests."
+        else:
+            message = "Unable to fetch URL, exiting: %s" % url
+        fail(message)
+
+
+def fail(msg):
+    print(msg)
+    clean_up()
+    sys.exit(-1)
+
+
+def run_cmd(cmd):
+    print(cmd)
+    try:
+        if isinstance(cmd, list):
+            return subprocess.check_output(cmd)
+        else:
+            return subprocess.check_output(cmd.split(" "))
+    except subprocess.CalledProcessError as e:
+        print("CallProcessError occurred. More information for process is below...")
+        print("Output - %s" % e.output)
+        print("Return code - %d" % e.returncode)
+        raise
+
+
+def continue_maybe(prompt):
+    result = raw_input("\n%s (y/n): " % prompt)
+    if result.lower() != "y":
+        fail("Okay, exiting")
+
+
+def clean_up():
+    print("Restoring head pointer to %s" % original_head)
+    run_cmd("git checkout %s" % original_head)
+
+    branches = run_cmd("git branch").replace(" ", "").split("\n")
+
+    for branch in filter(lambda x: x.startswith(BRANCH_PREFIX), branches):
+        print("Deleting local branch %s" % branch)
+        run_cmd("git branch -D %s" % branch)
+
+
+# merge the requested PR and return the merge hash
+def merge_pr(pr_num, target_ref, title, body, reviewers, pr_repo_desc):
+    pr_branch_name = "%s_MERGE_PR_%s" % (BRANCH_PREFIX, pr_num)
+    target_branch_name = "%s_MERGE_PR_%s_%s" % (BRANCH_PREFIX, pr_num, target_ref.upper())
+    run_cmd("git fetch %s pull/%s/head:%s" % (PR_REMOTE_NAME, pr_num, pr_branch_name))
+    run_cmd("git fetch %s %s:%s" % (PUSH_REMOTE_NAME, target_ref, target_branch_name))
+    run_cmd("git checkout %s" % target_branch_name)
+
+    commits = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
+                       '--pretty=format:%h [%an] %s']).split("\n")
+    commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
+                              '--pretty=format:%an <%ae>']).split("\n")
+    distinct_authors = sorted(set(commit_authors),
+                              key=lambda x: commit_authors.count(x), reverse=True)
+
+    print("Information of commits: %s" % (commits,))
+
+    if len(distinct_authors) > 1:
+        fail("We don't allow squashing commits which have multiple authors. You need to handle the merge manually. authors: %s" % (distinct_authors,))
+
+    primary_author = distinct_authors[0]
+
+    had_conflicts = False
+    try:
+        run_cmd(['git', 'merge', pr_branch_name, '--squash'])
+    except Exception as e:
+        msg = "Error merging: %s\nWould you like to manually fix-up this merge?" % e
+        continue_maybe(msg)
+        msg = "Okay, please fix any conflicts and 'git add' conflicting files... Finished?"
+        continue_maybe(msg)
+        had_conflicts = True
+
+    merge_message_flags = []
+
+    merge_message_flags += ["-m", title]
+    if body is not None:
+        # We remove @ symbols from the body to avoid triggering e-mails
+        # to people every time someone creates a public fork of Registry.
+        merge_message_flags += ["-m", body.replace("@", "")]
+
+    merge_message_flags += ["-m", "Author: %s" % primary_author]
+
+    if len(reviewers) > 0:
+        merge_message_flags += ["-m", "Reviewers: %s" % ",".join(reviewers)]
+
+    if had_conflicts:
+        committer_name = run_cmd("git config --get user.name").strip()
+        committer_email = run_cmd("git config --get user.email").strip()
+        message = "This patch had conflicts when merged, resolved by\nCommitter: %s <%s>" % (
+            committer_name, committer_email)
+        merge_message_flags += ["-m", message]
+
+    if len(commits) > 1:
+        result = raw_input("List pull request commits in squashed commit message? (y/n) [n]: ")
+        if result.lower() == "y":
+            should_list_commits = True
+        else:
+            should_list_commits = False
+    else:
+        should_list_commits = False
+
+    # The string "Closes #%s" string is required for GitHub to correctly close the PR
+    close_line = "Closes #%s from %s" % (pr_num, pr_repo_desc)
+    if should_list_commits:
+        close_line += " and squashes the following commits:"
+    merge_message_flags += ["-m", close_line]
+
+    if should_list_commits:
+        merge_message_flags += ["-m", "\n".join(commits)]
+
+    run_cmd(['git', 'commit', '--author="%s"' % primary_author] + merge_message_flags)
+
+    result = raw_input("Merge complete (local ref %s). Push to %s? (y/n)" %
+                       (target_branch_name, PUSH_REMOTE_NAME))
+    if result.lower() != "y":
+        result = raw_input("Exiting. Do you want to keep the current state? (expert only) (y/n)")
+        if result.lower() != "y":
+            fail("Okay, exiting")
+        else:
+            print("Okay, exiting without cleaning up.")
+            sys.exit(0)
+
+    try:
+        run_cmd('git push %s %s:%s' % (PUSH_REMOTE_NAME, target_branch_name, target_ref))
+    except Exception as e:
+        clean_up()
+        fail("Exception while pushing: %s" % e)
+
+    merge_hash = run_cmd("git rev-parse %s" % target_branch_name)[:8]
+    clean_up()
+    print("Pull request #%s merged!" % pr_num)
+    print("Merge hash: %s" % merge_hash)
+    return merge_hash
+
+
+def get_current_ref():
+    ref = run_cmd("git rev-parse --abbrev-ref HEAD").strip()
+    if ref == 'HEAD':
+        # The current ref is a detached HEAD, so grab its SHA.
+        return run_cmd("git rev-parse HEAD").strip()
+    else:
+        return ref
+
+
+def get_remotes():
+    remotes_output = run_cmd("git remote -v").strip().split("\n")
+    return set(map(lambda x: x.split("\t")[0], remotes_output))
+
+
+def main():
+    global original_head
+
+    os.chdir(REGISTRY_HOME)
+    original_head = get_current_ref()
+    remotes = get_remotes()
+
+    if not PR_REMOTE_NAME in remotes:
+      fail("Remote for pull request [%s] not registered" % PR_REMOTE_NAME)
+
+    if not PUSH_REMOTE_NAME in remotes:
+      fail("Remote for push [%s] not registered" % PUSH_REMOTE_NAME)
+
+    pr_num = raw_input("Which pull request would you like to merge? (e.g. 34): ")
+    pr = get_json("%s/pulls/%s" % (GITHUB_API_BASE, pr_num))
+
+    url = pr["url"]
+
+    print("The title of PR: %s" % pr["title"])
+
+    if not pr["title"].startswith("ISSUE-"):
+        print("The title of PR doesn't conform to the Registry rule: doesn't start with 'ISSUE-'")
+        continue_maybe("Continue merging?")
+
+        result = raw_input("Do you want to modify the title before continue? (y/n): ")
+        if result.lower() == "y":
+            title_str = raw_input("New title: ")
+            title = title_str.strip()
+        else:
+            print("OK. Will use PR's title.")
+            title = pr["title"]
+    else:
+        title = pr["title"]
+
+    body = pr["body"]
+
+    if not body or len(body.strip()) <= 0:
+        print("WARN: The body of PR doesn't have any content which should have information of PR.")
+        print("If you continue merging, commit title is available but commit message may be empty.")
+        continue_maybe("Do you want to continue?")
+
+    target_ref = pr["base"]["ref"]
+    user_login = pr["user"]["login"]
+    base_ref = pr["head"]["ref"]
+    pr_repo_desc = "%s/%s" % (user_login, base_ref)
+
+    if pr["state"] != "open":
+        fail("The state of PR is not 'open'. We don't want to deal with closed PR.")
+
+    if not bool(pr["mergeable"]):
+        msg = "Pull request %s is not mergeable in its current form.\n" % pr_num + \
+            "Continue? (experts only!)"
+        continue_maybe(msg)
+
+    print("\n=== Pull Request #%s ===" % pr_num)
+    print("title\t%s\nsource\t%s\ntarget\t%s\nurl\t%s" %
+          (title, pr_repo_desc, target_ref, url))
+    continue_maybe("Proceed with merging pull request #%s?" % pr_num)
+
+    review_comments = get_json("%s/pulls/%s/reviews" % (GITHUB_API_BASE, pr_num))
+
+    reviewers = set(map(lambda x: "@" + x["user"]["login"], review_comments))
+
+    merge_pr(pr_num, target_ref, title, body, reviewers, pr_repo_desc)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        # don't clean_up() while receiving SystemExit: the situation might be normal exit
+        pass
+    except:
+        clean_up()
+        raise


### PR DESCRIPTION
* introduce merge script which is based on Spark merge script and borrow some block from Kafka
  * removed unnecessary parts regarding porting back, handling JIRA issues including marking versions

This closes #263 but need to remove CHANGELOG.md separately since including removal of CHANGELOG.md will incur merge conflict.

Please play with merge script to determine how it works and how it configures commit title and commit message of squashed commit.
The script is not that complicated if you are familiar with git command so you may want to also read the script.

Please note that PR's body is picked for squashed commit message instead of accumulation of commit messages in PR's commits. This is based on the decision that Spark / Kafka / etc projects define the template of pull request which guarantees the PR's body to be valuable to get into commit message.

What merge script is doing:

* It checks the title of PR to verify it conforms to the rule: the title of PR should be started with ‘ISSUE-‘.
  * It also means that pull requests should be based on corresponding issues.
  * If the PR doesn’t respect the rule, merger can stop merging, force use the title, fix the title manually.
* It checks out target branch and PR’s branch, and squash commits in PR into one.
  * If there’re multiple authors in PR, it just stops merging instead of enumerating authors and letting merge pick primary author.
    * This was a blocker for Storm introducing similar merge script.
    * For now, we can rely on merger to handle the case manually instead of making script much complicated.
  * Commit title will be the title of PR.
  * Commit message will contain below things:
    * The body of PR
    * The information of author(s)
    * The information of merger if merger resolves merge conflict manually
    * The origin commits on PR if necessary (optional)
    * Auto close message for Github PR
* Push the squashed commit to the remote (HWX gerrit repository).