### PR TITLE
ISSUE-275: Fix a few maven dependencies for storage-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,8 +282,8 @@
         <phoenix.version>4.4.0-HBase-1.1</phoenix.version>
         <mariadb-java-client.version>1.5.5</mariadb-java-client.version>
         <calcite.version>1.4.0-incubating</calcite.version>
-        <commons-lang3.version>3.3</commons-lang3.version>
-        <commons-lang.version>2.5</commons-lang.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
+        <commons-lang.version>2.6</commons-lang.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
         <maven-surefire.version>2.18.1</maven-surefire.version>
         <maven-shade-plugin.version>2.4.1</maven-shade-plugin.version>
@@ -291,6 +291,8 @@
         <spring.version>4.3.6.RELEASE</spring.version>
         <postgresql.version>9.4.1212</postgresql.version>
         <flyway.version>4.2.0</flyway.version>
+        <hikari.version>2.2.5</hikari.version>
+        <h2database.version>1.4.188</h2database.version>
     </properties>
 
     <distributionManagement>
@@ -530,7 +532,16 @@
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>${flyway.version}</version>
             </dependency>
-
+            <dependency>
+              <groupId>com.zaxxer</groupId>
+              <artifactId>HikariCP-java6</artifactId>
+              <version>${hikari.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>commons-lang</groupId>
+              <artifactId>commons-lang</artifactId>
+              <version>${commons-lang.version}</version>
+            </dependency>
 
             <!-- Test dependencies -->
             <dependency>

--- a/storage/core/pom.xml
+++ b/storage/core/pom.xml
@@ -11,12 +11,6 @@
 
     <artifactId>storage-core</artifactId>
 
-    <properties>
-        <hikari.version>2.2.5</hikari.version>
-        <commons-lang.version>2.5</commons-lang.version>
-        <h2database.version>1.4.188</h2database.version>
-    </properties>
-
     <dependencies>
         <!-- module dependency -->
         <dependency>
@@ -48,71 +42,16 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP-java6</artifactId>
-            <version>${hikari.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.phoenix</groupId>
-            <artifactId>phoenix-core</artifactId>
-            <version>${phoenix.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-json</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty-sslengine</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jsp-2.1</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jsp-api-2.1</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>servlet-api-2.5</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-mapreduce-client-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        
         <!--test-->
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -126,6 +126,11 @@
             <version>${curator.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
After moving storage-core from registry to streamline a few minor version dependencies needs to be updated to make it in sync with what was shipped in streamline.
Also phoenix dependency is no longer required for storage-core.