### PR TITLE
ISSUE-284 Fix the build failure on Travis CI

### DIFF
--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -23,7 +23,7 @@ cd ${SRC_ROOT_DIR}
 # Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
 export MAVEN_OPTS="-Xmx1024m"
 
-mvn --batch-mode test -Dmaven.test.redirectTestOutputToFile=true
+mvn --batch-mode verify -Dmaven.test.redirectTestOutputToFile=true
 BUILD_RET_VAL=$?
 
 for dir in `find . -type d -and -wholename \*/target/surefire-reports`;

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -23,10 +23,10 @@ cd ${SRC_ROOT_DIR}
 # Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
 export MAVEN_OPTS="-Xmx1024m"
 
-mvn --batch-mode test -fae 
+mvn --batch-mode test -Dmaven.test.redirectTestOutputToFile=true
 BUILD_RET_VAL=$?
 
-for dir in `find . -type d -and -wholename \*/target/\*-reports`;
+for dir in `find . -type d -and -wholename \*/target/surefire-reports`;
 do
 echo "Looking for errors in ${dir}"
 python ${TRAVIS_SCRIPT_DIR}/print-errors-from-test-reports.py "${dir}"


### PR DESCRIPTION
* add '-Dmaven.test.redirectTestOutputToFile=true' to redirect test output to file
* print failed tests with output after detecting failure

This patch works without #256. Some tests have lots of output hence exceed 4 mb even printing output only for those tests but I don't think it is a big deal.