### PR TITLE
ISSUE-289 Throw more specific Exceptions

### DIFF
--- a/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/exceptions/RegistryException.java
+++ b/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/exceptions/RegistryException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hortonworks.registries.schemaregistry.exceptions;
+
+import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+
+/**
+ * This is thrown when an exception is caused due to the Schema Registry.
+ * This should be the default, unless the caught exception is retryable,
+ * where {@link com.hortonworks.registries.schemaregistry.exceptions.RegistryRetryableException} 
+ * should be thrown instead.
+ */
+public class RegistryException extends SerDesException {
+
+   public RegistryException() {
+   }
+
+   public RegistryException(String message) {
+      super(message);
+   }
+
+   public RegistryException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public RegistryException(Throwable cause) {
+      super(cause);
+   }
+
+   public RegistryException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+   }
+}

--- a/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/exceptions/RegistryRetryableException.java
+++ b/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/exceptions/RegistryRetryableException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hortonworks.registries.schemaregistry.exceptions;
+
+import com.hortonworks.registries.schemaregistry.serde.RetryableException;
+
+/**
+ * This is thrown when an exception is caused due to the Schema Registry, 
+ * and the exception is deemed retry-able, e.g. cause being IOException.
+ */
+public class RegistryRetryableException extends RegistryException implements RetryableException {
+
+   public RegistryRetryableException() {
+   }
+
+   public RegistryRetryableException(String message) {
+      super(message);
+   }
+
+   public RegistryRetryableException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public RegistryRetryableException(Throwable cause) {
+      super(cause);
+   }
+
+   public RegistryRetryableException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+   }
+}

--- a/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/serde/AbstractSnapshotSerializer.java
+++ b/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/serde/AbstractSnapshotSerializer.java
@@ -19,14 +19,12 @@ import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
 import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.SchemaVersion;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
-import com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.errors.IncompatibleSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
+import com.hortonworks.registries.schemaregistry.exceptions.RegistryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * This class implements {@link SnapshotSerializer} and internally creates schema registry client to connect to the
@@ -65,8 +63,8 @@ public abstract class AbstractSnapshotSerializer<I, O> extends AbstractSerDes im
             SchemaIdVersion schemaIdVersion = schemaRegistryClient.addSchemaVersion(schemaMetadata, new SchemaVersion(schema, "Schema registered by serializer:" + this.getClass()));
             // write the version and given object to the output
             return doSerialize(input, schemaIdVersion);
-        } catch (InvalidSchemaException | IncompatibleSchemaException | SchemaNotFoundException e) {
-            throw new SerDesException(e);
+        } catch (SchemaNotFoundException | IncompatibleSchemaException | InvalidSchemaException e) {
+            throw new RegistryException(e);
         }
     }
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/serde/RetryableException.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/serde/RetryableException.java
@@ -1,0 +1,7 @@
+package com.hortonworks.registries.schemaregistry.serde;
+
+/**
+ * Interface use to denote an exception that could be retried, and may become successful.
+ */
+public interface RetryableException {
+}

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSerDesProtocolHandler.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSerDesProtocolHandler.java
@@ -16,8 +16,8 @@
 package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import com.hortonworks.registries.schemaregistry.serdes.SerDesProtocolHandler;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
@@ -57,7 +57,7 @@ public abstract class AbstractAvroSerDesProtocolHandler implements SerDesProtoco
             outputStream.write(new byte[]{protocolId});
             doHandleSchemaVersionSerialization(outputStream, schemaIdVersion);
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
     }
 

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotDeserializer.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotDeserializer.java
@@ -29,6 +29,7 @@ import com.hortonworks.registries.schemaregistry.avro.AvroSchemaResolver;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
+import com.hortonworks.registries.schemaregistry.exceptions.RegistryException;
 import com.hortonworks.registries.schemaregistry.serde.AbstractSnapshotDeserializer;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import com.hortonworks.registries.schemaregistry.serdes.SerDesProtocolHandler;
@@ -161,7 +162,7 @@ public abstract class AbstractAvroSnapshotDeserializer<I> extends AbstractSnapsh
         LOG.debug("SchemaKey: [{}] for the received payload", writerSchemaVersionKey);
         Schema writerSchema = getSchema(writerSchemaVersionKey);
         if (writerSchema == null) {
-            throw new SerDesException("No schema exists with metadata-key: " + schemaMetadata + " and writerSchemaVersion: " + writerSchemaVersion);
+            throw new RegistryException("No schema exists with metadata-key: " + schemaMetadata + " and writerSchemaVersion: " + writerSchemaVersion);
         }
         Schema readerSchema = readerSchemaVersion != null ? getSchema(new SchemaVersionKey(schemaName, readerSchemaVersion)) : null;
 

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotSerializer.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotSerializer.java
@@ -24,6 +24,7 @@ import com.hortonworks.registries.schemaregistry.serde.AbstractSnapshotSerialize
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import com.hortonworks.registries.schemaregistry.serde.SnapshotDeserializer;
 import com.hortonworks.registries.schemaregistry.serdes.SerDesProtocolHandler;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
 import org.apache.avro.Schema;
 
 import java.io.OutputStream;
@@ -99,7 +100,7 @@ public abstract class AbstractAvroSnapshotSerializer<O> extends AbstractSnapshot
 
         SerDesProtocolHandler serDesProtocolHandler = SerDesProtocolHandlerRegistry.get().getSerDesProtocolHandler(protocolVersion);
         if (serDesProtocolHandler == null) {
-            throw new IllegalArgumentException("SerDesProtocolHandler with protocol version " + protocolVersion + " does not exist");
+            throw new AvroException("SerDesProtocolHandler with protocol version " + protocolVersion + " does not exist");
         }
 
         this.serDesProtocolHandler = serDesProtocolHandler;
@@ -109,7 +110,7 @@ public abstract class AbstractAvroSnapshotSerializer<O> extends AbstractSnapshot
         final long x;
         if ((x = number.longValue()) != number.doubleValue()
                 || (x < 0 || x > Byte.MAX_VALUE)) {
-            throw new IllegalArgumentException(SERDES_PROTOCOL_VERSION+ " value should be in [0, "+Byte.MAX_VALUE+"]");
+            throw new AvroException(SERDES_PROTOCOL_VERSION + " value should be in [0, " + Byte.MAX_VALUE + "]");
         }
     }
 

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroSnapshotDeserializer.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroSnapshotDeserializer.java
@@ -19,6 +19,8 @@ import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
 import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,11 +56,11 @@ public class AvroSnapshotDeserializer extends AbstractAvroSnapshotDeserializer<I
         try {
             protocolId = (byte) inputStream.read();
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
 
         if (protocolId == -1) {
-            throw new SerDesException("End of stream reached while trying to read protocol id");
+            throw new AvroException("End of stream reached while trying to read protocol id");
         }
 
         checkProtocolHandlerExists(protocolId);
@@ -68,7 +70,7 @@ public class AvroSnapshotDeserializer extends AbstractAvroSnapshotDeserializer<I
 
     private void checkProtocolHandlerExists(byte protocolId) {
         if (SerDesProtocolHandlerRegistry.get().getSerDesProtocolHandler(protocolId) == null) {
-            throw new SerDesException("Unknown protocol id [" + protocolId + "] received while deserializing the payload");
+            throw new AvroException("Unknown protocol id [" + protocolId + "] received while deserializing the payload");
         }
     }
 

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroSnapshotSerializer.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroSnapshotSerializer.java
@@ -18,6 +18,7 @@ package com.hortonworks.registries.schemaregistry.serdes.avro;
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -54,7 +55,7 @@ public class AvroSnapshotSerializer extends AbstractAvroSnapshotSerializer<byte[
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
     }
 

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroUtils.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroUtils.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry.serdes.avro;
 
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 
@@ -63,7 +64,7 @@ public final class AvroUtils {
         } else if (input instanceof Boolean) {
             type = Schema.Type.BOOLEAN;
         } else {
-            throw new RuntimeException("input type: " + input.getClass() + " is not supported");
+            throw new AvroException("input type: " + input.getClass() + " is not supported");
         }
 
         return PRIMITIVE_SCHEMAS.get(type);

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/ConfluentProtocolHandler.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/ConfluentProtocolHandler.java
@@ -21,7 +21,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,14 +42,14 @@ public class ConfluentProtocolHandler extends AbstractAvroSerDesProtocolHandler 
                                                       SchemaIdVersion schemaIdVersion) {
         Long versionId = schemaIdVersion.getSchemaVersionId();
         if (versionId > Integer.MAX_VALUE) {
-            throw new SerDesException("Unsupported versionId, max id=" + Integer.MAX_VALUE + " , but was id=" + versionId);
+            throw new AvroException("Unsupported versionId, max id=" + Integer.MAX_VALUE + " , but was id=" + versionId);
         } else {
             // 4 bytes
             try {
                 outputStream.write(ByteBuffer.allocate(4)
                                              .putInt(versionId.intValue()).array());
             } catch (IOException e) {
-                throw new SerDesException(e);
+                throw new AvroRetryableException(e);
             }
         }
     }
@@ -59,7 +60,7 @@ public class ConfluentProtocolHandler extends AbstractAvroSerDesProtocolHandler 
         try {
             inputStream.read(byteBuffer.array());
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
 
         int schemaVersionId = byteBuffer.getInt();

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/SchemaMetadataIdProtocolHandler.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/SchemaMetadataIdProtocolHandler.java
@@ -17,6 +17,7 @@ package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,7 +43,7 @@ public class SchemaMetadataIdProtocolHandler extends AbstractAvroSerDesProtocolH
                                          .putLong(schemaIdVersion.getSchemaMetadataId())
                                          .putInt(schemaIdVersion.getVersion()).array());
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
     }
 
@@ -54,7 +55,7 @@ public class SchemaMetadataIdProtocolHandler extends AbstractAvroSerDesProtocolH
         try {
             inputStream.read(byteBuffer.array());
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
 
         long schemaMetadataId = byteBuffer.getLong();

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/SchemaVersionIdAsIntProtocolHandler.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/SchemaVersionIdAsIntProtocolHandler.java
@@ -16,7 +16,8 @@
 package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class SchemaVersionIdAsIntProtocolHandler extends AbstractAvroSerDesProto
                 outputStream.write(ByteBuffer.allocate(4)
                                              .putInt(versionId.intValue()).array());
             } catch (IOException e) {
-                throw new SerDesException(e);
+                throw new AvroException(e);
             }
         }
     }
@@ -69,7 +70,7 @@ public class SchemaVersionIdAsIntProtocolHandler extends AbstractAvroSerDesProto
         try {
             inputStream.read(byteBuffer.array());
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
 
         int schemaVersionId = byteBuffer.getInt();

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/SchemaVersionIdAsLongProtocolHandler.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/SchemaVersionIdAsLongProtocolHandler.java
@@ -17,6 +17,7 @@ package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,7 +41,7 @@ public class SchemaVersionIdAsLongProtocolHandler extends AbstractAvroSerDesProt
             outputStream.write(ByteBuffer.allocate(8)
                                          .putLong(versionId).array());
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
     }
 
@@ -50,7 +51,7 @@ public class SchemaVersionIdAsLongProtocolHandler extends AbstractAvroSerDesProt
         try {
             inputStream.read(byteBuffer.array());
         } catch (IOException e) {
-            throw new SerDesException(e);
+            throw new AvroRetryableException(e);
         }
 
         return new SchemaIdVersion(byteBuffer.getLong());

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/exceptions/AvroException.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/exceptions/AvroException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hortonworks.registries.schemaregistry.serdes.avro.exceptions;
+
+import com.hortonworks.registries.schemaregistry.serde.SerDesException;
+
+/**
+ * This is thrown when an exception is caused due to Avro to binary (or vice versa) conversion.
+ * This should be the default, unless the caught exception is retryable,
+ * where {@link com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroRetryableException}
+ * should be thrown instead.
+ */
+public class AvroException extends SerDesException {
+
+   public AvroException() {
+   }
+
+   public AvroException(String message) {
+      super(message);
+   }
+
+   public AvroException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public AvroException(Throwable cause) {
+      super(cause);
+   }
+
+   public AvroException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+   }
+   
+}

--- a/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/exceptions/AvroRetryableException.java
+++ b/schema-registry/serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/exceptions/AvroRetryableException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Hortonworks.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hortonworks.registries.schemaregistry.serdes.avro.exceptions;
+
+import com.hortonworks.registries.schemaregistry.serde.RetryableException;
+
+/**
+ * This is thrown when an exception is caused due to Avro to binary (or vice versa) conversion, 
+ * and the exception is deemed retry-able, e.g. cause being IOException.
+ */
+public class AvroRetryableException extends AvroException implements RetryableException {
+
+   public AvroRetryableException() {
+   }
+
+   public AvroRetryableException(String message) {
+      super(message);
+   }
+
+   public AvroRetryableException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public AvroRetryableException(Throwable cause) {
+      super(cause);
+   }
+
+   public AvroRetryableException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+   }
+   
+}

--- a/schema-registry/serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/SchemaVersionProtocolHandlerTest.java
+++ b/schema-registry/serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/SchemaVersionProtocolHandlerTest.java
@@ -27,6 +27,7 @@ import com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.serdes.avro.AvroSnapshotDeserializer;
 import com.hortonworks.registries.schemaregistry.serdes.avro.AvroSnapshotSerializer;
 import com.hortonworks.registries.schemaregistry.serdes.avro.SerDesProtocolHandlerRegistry;
+import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
 import com.hortonworks.registries.serdes.Device;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -104,12 +105,12 @@ public class SchemaVersionProtocolHandlerTest {
        _testSerDes(1L, 1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = AvroException.class)
     public void testSerDesProtocolVersionAsMoreThan127() throws Exception {
        _testSerDes(1L, Byte.MAX_VALUE + Math.abs(new Random().nextInt()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = AvroException.class)
     public void testSerDesProtocolVersionAsLessThanZero() throws Exception {
         _testSerDes(1L, new Random().nextInt(127) - 128);
     }


### PR DESCRIPTION
Create new base exceptions that extend SerdesException to keep current contract but to allow a basic seperation between a Registry issue or an Avro issue.
Create further extensions on those for more specific exceptions to wrap the underlying exceptions so a serdes client can distinguish failure types.