### PR TITLE
ISSUE-331 - Add adminConnector config with a specific port so that users know about the configuration from which SR server is running.

### DIFF
--- a/conf/registry-inmemory-example.yaml
+++ b/conf/registry-inmemory-example.yaml
@@ -13,6 +13,7 @@ modules:
       # inmemory schema version cache entry expiry interval after access
       schemaCacheExpiryInterval: 3600
 
+
 servletFilters:
 # - className: "com.hortonworks.registries.auth.server.AuthenticationFilter"
 #   params:
@@ -48,17 +49,9 @@ fileStorageConfiguration:
   properties:
     directory: "/tmp/schema-registry/jars"
 
-# Oracle based jdbc provider configuration is:
+# storage provider configuration
 storageProviderConfiguration:
- providerClass: "com.hortonworks.registries.storage.impl.jdbc.JdbcStorageManager"
- properties:
-   db.type: "oracle"
-   queryTimeoutInSecs: 5
-   db.properties:
-     dataSourceClassName: "oracle.jdbc.pool.OracleDataSource"
-     dataSource.url: "jdbc:oracle:thin:@localhost:1521/orclpdb1.localdomain"
-     dataSource.user: "registry_user"
-     dataSource.password: "registry_user_passwd"
+ providerClass: "com.hortonworks.registries.storage.impl.memory.InMemoryStorageManager"
 
 #swagger configuration
 swagger:
@@ -71,6 +64,9 @@ server:
   applicationConnectors:
     - type: http
       port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
 
 # Logging settings.
 logging:

--- a/conf/registry-mysql-example.yaml
+++ b/conf/registry-mysql-example.yaml
@@ -48,17 +48,17 @@ fileStorageConfiguration:
   properties:
     directory: "/tmp/schema-registry/jars"
 
-# Postgres based jdbc provider configuration is:
+# MySQL based jdbc provider configuration is:
 storageProviderConfiguration:
  providerClass: "com.hortonworks.registries.storage.impl.jdbc.JdbcStorageManager"
  properties:
-   db.type: "postgresql"
+   db.type: "mysql"
    queryTimeoutInSecs: 30
    db.properties:
-     dataSourceClassName: "org.postgresql.ds.PGSimpleDataSource"
-     dataSource.url: "jdbc:postgresql://localhost/schema_registry"
-     dataSource.user: "postgres"
-     dataSource.password: "postgres"
+     dataSourceClassName: "com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
+     dataSource.url: "jdbc:mysql://localhost/schema_registry"
+     dataSource.user: "registry_user"
+     dataSource.password: "registry_password"
 
 #swagger configuration
 swagger:
@@ -71,6 +71,9 @@ server:
   applicationConnectors:
     - type: http
       port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
 
 # Logging settings.
 logging:

--- a/conf/registry-oracle-example.yaml
+++ b/conf/registry-oracle-example.yaml
@@ -13,7 +13,6 @@ modules:
       # inmemory schema version cache entry expiry interval after access
       schemaCacheExpiryInterval: 3600
 
-
 servletFilters:
 # - className: "com.hortonworks.registries.auth.server.AuthenticationFilter"
 #   params:
@@ -49,9 +48,17 @@ fileStorageConfiguration:
   properties:
     directory: "/tmp/schema-registry/jars"
 
-# storage provider configuration
+# Oracle based jdbc provider configuration is:
 storageProviderConfiguration:
- providerClass: "com.hortonworks.registries.storage.impl.memory.InMemoryStorageManager"
+ providerClass: "com.hortonworks.registries.storage.impl.jdbc.JdbcStorageManager"
+ properties:
+   db.type: "oracle"
+   queryTimeoutInSecs: 5
+   db.properties:
+     dataSourceClassName: "oracle.jdbc.pool.OracleDataSource"
+     dataSource.url: "jdbc:oracle:thin:@localhost:1521/orclpdb1.localdomain"
+     dataSource.user: "registry_user"
+     dataSource.password: "registry_user_passwd"
 
 #swagger configuration
 swagger:
@@ -64,6 +71,9 @@ server:
   applicationConnectors:
     - type: http
       port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
 
 # Logging settings.
 logging:

--- a/conf/registry-postgres-example.yaml
+++ b/conf/registry-postgres-example.yaml
@@ -48,17 +48,17 @@ fileStorageConfiguration:
   properties:
     directory: "/tmp/schema-registry/jars"
 
-# MySQL based jdbc provider configuration is:
+# Postgres based jdbc provider configuration is:
 storageProviderConfiguration:
  providerClass: "com.hortonworks.registries.storage.impl.jdbc.JdbcStorageManager"
  properties:
-   db.type: "mysql"
+   db.type: "postgresql"
    queryTimeoutInSecs: 30
    db.properties:
-     dataSourceClassName: "com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
-     dataSource.url: "jdbc:mysql://localhost/schema_registry"
-     dataSource.user: "registry_user"
-     dataSource.password: "registry_password"
+     dataSourceClassName: "org.postgresql.ds.PGSimpleDataSource"
+     dataSource.url: "jdbc:postgresql://localhost/schema_registry"
+     dataSource.user: "postgres"
+     dataSource.password: "postgres"
 
 #swagger configuration
 swagger:
@@ -71,6 +71,9 @@ server:
   applicationConnectors:
     - type: http
       port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
 
 # Logging settings.
 logging:

--- a/conf/registry.yaml
+++ b/conf/registry.yaml
@@ -77,6 +77,9 @@ server:
   applicationConnectors:
     - type: http
       port: 9090
+  adminConnectors:
+    - type: http
+      port: 9091
 
 # Logging settings.
 logging:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -59,9 +59,9 @@ CentOS/RedHat
 
 ::
 
-  cp conf/registry.yaml.mysql.example conf/registry.yaml
+  cp conf/registry-mysql-example.yaml conf/registry.yaml
 
-Edit the folllowing section to add appropriate database and user settings
+Edit the following section to add appropriate database and user settings
 
 ::
 
@@ -139,9 +139,9 @@ OS X
 
 ::
 
-  cp conf/registry.yaml.mysql.example conf/registry.yaml
+  cp conf/registry-mysql-example.yaml conf/registry.yaml
 
-Edit the folllowing section to add appropriate database and user settings
+Edit the following section to add appropriate database and user settings
 
 ::
 


### PR DESCRIPTION
- Add adminConnector config with a specific port so that users know about the configuration from which SR server is running.
- Change this to 9091 as 8081 default port may have been used by other applications.
- Renamed example config files appropriately.