### PR TITLE
ISSUE-398 Add an option to disable validation during schema migration in storage-tool

### DIFF
--- a/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/SchemaFlywayFactory.java
+++ b/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/SchemaFlywayFactory.java
@@ -33,14 +33,14 @@ public class SchemaFlywayFactory {
     private static final boolean cleanOnValidationError = false;
 
 
-    public static Flyway get(StorageProviderConfiguration conf, String scriptRootPath, Boolean disableValidationOnMigrate) {
+    public static Flyway get(StorageProviderConfiguration conf, String scriptRootPath, boolean validateOnMigrate) {
         Flyway flyway = new Flyway();
 
         String location = "filesystem:" + scriptRootPath + File.separator + conf.getDbType();
         flyway.setEncoding(encoding);
         flyway.setTable(metaDataTableName);
         flyway.setSqlMigrationPrefix(sqlMigrationPrefix);
-        flyway.setValidateOnMigrate(!disableValidationOnMigrate);
+        flyway.setValidateOnMigrate(validateOnMigrate);
         flyway.setOutOfOrder(outOfOrder);
         flyway.setBaselineOnMigrate(baselineOnMigrate);
         flyway.setBaselineVersion(MigrationVersion.fromVersion(baselineVersion));

--- a/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/SchemaFlywayFactory.java
+++ b/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/SchemaFlywayFactory.java
@@ -27,21 +27,20 @@ public class SchemaFlywayFactory {
     private static final String encoding = StandardCharsets.UTF_8.name();
     private static final String metaDataTableName = "DATABASE_CHANGE_LOG";
     private static final String sqlMigrationPrefix = "v";
-    private static final boolean validateOnMigrate = true;
     private static final boolean outOfOrder = false;
     private static final boolean baselineOnMigrate = true;
     private static final String baselineVersion = "000";
     private static final boolean cleanOnValidationError = false;
 
 
-    public static Flyway get(StorageProviderConfiguration conf, String scriptRootPath) {
+    public static Flyway get(StorageProviderConfiguration conf, String scriptRootPath, Boolean disableValidationOnMigrate) {
         Flyway flyway = new Flyway();
 
         String location = "filesystem:" + scriptRootPath + File.separator + conf.getDbType();
         flyway.setEncoding(encoding);
         flyway.setTable(metaDataTableName);
         flyway.setSqlMigrationPrefix(sqlMigrationPrefix);
-        flyway.setValidateOnMigrate(validateOnMigrate);
+        flyway.setValidateOnMigrate(!disableValidationOnMigrate);
         flyway.setOutOfOrder(outOfOrder);
         flyway.setBaselineOnMigrate(baselineOnMigrate);
         flyway.setBaselineVersion(MigrationVersion.fromVersion(baselineVersion));

--- a/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/TablesInitializer.java
+++ b/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/TablesInitializer.java
@@ -176,11 +176,11 @@ public class TablesInitializer {
             throw new IllegalStateException("Shouldn't reach here");
         }
 
-        Boolean disableValidateOnMigrate = commandLine.hasOption(DISABLE_VALIDATE_ON_MIGRATE);
+        boolean disableValidateOnMigrate = commandLine.hasOption(DISABLE_VALIDATE_ON_MIGRATE);
         if(disableValidateOnMigrate) {
             System.out.println("Disabling validation on schema migrate");
         }
-        SchemaMigrationHelper schemaMigrationHelper = new SchemaMigrationHelper(SchemaFlywayFactory.get(storageProperties, scriptRootPath, disableValidateOnMigrate));
+        SchemaMigrationHelper schemaMigrationHelper = new SchemaMigrationHelper(SchemaFlywayFactory.get(storageProperties, scriptRootPath, !disableValidateOnMigrate));
         try {
             schemaMigrationHelper.execute(schemaMigrationOptionSpecified);
             System.out.println(String.format("\"%s\" option successful", schemaMigrationOptionSpecified.toString()));

--- a/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/TablesInitializer.java
+++ b/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/TablesInitializer.java
@@ -30,6 +30,7 @@ public class TablesInitializer {
     private static final String OPTION_SCRIPT_ROOT_PATH = "script-root";
     private static final String OPTION_CONFIG_FILE_PATH = "config";
     private static final String OPTION_MYSQL_JAR_URL_PATH = "mysql-jar-url";
+    private static final String DISABLE_VALIDATE_ON_MIGRATE = "disable-validate-on-migrate";
 
 
     public static void main(String[] args) throws Exception {
@@ -115,6 +116,14 @@ public class TablesInitializer {
                         .build()
         );
 
+        options.addOption(
+                Option.builder()
+                    .hasArg(false)
+                    .longOpt(DISABLE_VALIDATE_ON_MIGRATE)
+                    .desc("Disable flyway validation checks while running migrate")
+                    .build()
+        );
+
         CommandLineParser parser = new BasicParser();
         CommandLine commandLine = parser.parse(options, args);
 
@@ -167,7 +176,11 @@ public class TablesInitializer {
             throw new IllegalStateException("Shouldn't reach here");
         }
 
-        SchemaMigrationHelper schemaMigrationHelper = new SchemaMigrationHelper(SchemaFlywayFactory.get(storageProperties, scriptRootPath));
+        Boolean disableValidateOnMigrate = commandLine.hasOption(DISABLE_VALIDATE_ON_MIGRATE);
+        if(disableValidateOnMigrate) {
+            System.out.println("Disabling validation on schema migrate");
+        }
+        SchemaMigrationHelper schemaMigrationHelper = new SchemaMigrationHelper(SchemaFlywayFactory.get(storageProperties, scriptRootPath, disableValidateOnMigrate));
         try {
             schemaMigrationHelper.execute(schemaMigrationOptionSpecified);
             System.out.println(String.format("\"%s\" option successful", schemaMigrationOptionSpecified.toString()));


### PR DESCRIPTION
Add an option to disable validation during schema migration in storage-tool.

Closes #398 