### PR TITLE
ISSUE-410 (v0.3.1) AvroFieldsGenerator produces Stackoverflow error when parsing a nested record schema.

### DIFF
--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
@@ -49,6 +49,7 @@ public class AvroFieldsGenerator {
 
             List<Schema.Field> fields = schema.getFields();
             Set<String> visitedRecords = new HashSet<>();
+            visitedRecords.add(schema.getFullName());
             for (Schema.Field field : fields) {
                 parseField(field, schemaFieldInfos, visitedRecords);
             }
@@ -83,8 +84,7 @@ public class AvroFieldsGenerator {
                 String completeName = schema.getFullName();
 
                 if (visitedRecords.contains(completeName)) {
-                    // It seems like the goal of this class is to only return a list of all primitive fields.
-                    //   If we encounter a record that was already parsed, then just ignore it...
+                    // Since we are only interested in primitive data types, if we encounter a record that was already parsed it can be ignored
                     break;
                 }
                 else {

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
@@ -21,7 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -46,13 +48,14 @@ public class AvroFieldsGenerator {
             LOG.debug("Schema full name: [{}]", fullName);
 
             List<Schema.Field> fields = schema.getFields();
+            Set<String> visitedRecords = new HashSet<>();
             for (Schema.Field field : fields) {
-                parseField(field, schemaFieldInfos);
+                parseField(field, schemaFieldInfos, visitedRecords);
             }
         }
     }
 
-    private void parseField(Schema.Field field, List<SchemaFieldInfo> schemaFieldInfos) {
+    private void parseField(Schema.Field field, List<SchemaFieldInfo> schemaFieldInfos, Set<String> visitedRecords) {
         Schema schema = field.schema();
         Schema.Type type = schema.getType();
         String name = field.name();
@@ -67,36 +70,48 @@ public class AvroFieldsGenerator {
         schemaFieldInfos.add(new SchemaFieldInfo(namespace, name, type.name()));
 
         // todo check whether fields should be mapped to the root schema.
-        parseSchema(schema, schemaFieldInfos);
+        parseSchema(schema, schemaFieldInfos, visitedRecords);
     }
 
-    private void parseSchema(Schema schema, List<SchemaFieldInfo> schemaFieldInfos) {
+    private void parseSchema(Schema schema, List<SchemaFieldInfo> schemaFieldInfos, Set<String> visitedRecords) {
         Schema.Type type = schema.getType();
         LOG.debug("Visiting type: [{}]", type);
 
         switch (type) {
             case RECORD:
-                // store fields of a record.
-                List<Schema.Field> fields = schema.getFields();
-                for (Schema.Field recordField : fields) {
-                    parseField(recordField, schemaFieldInfos);
+
+                String completeName = schema.getFullName();
+
+                if (visitedRecords.contains(completeName)) {
+                    // It seems like the goal of this class is to only return a list of all primitive fields.
+                    //   If we encounter a record that was already parsed, then just ignore it...
+                    break;
+                }
+                else {
+                    visitedRecords.add(completeName);
+
+                    // store fields of a record.
+                    List<Schema.Field> fields = schema.getFields();
+                    for (Schema.Field recordField : fields) {
+                        parseField(recordField, schemaFieldInfos, visitedRecords);
+                    }
                 }
                 break;
             case MAP:
                 Schema valueTypeSchema = schema.getValueType();
-                parseSchema(valueTypeSchema, schemaFieldInfos);
+                parseSchema(valueTypeSchema, schemaFieldInfos, visitedRecords);
                 break;
             case ENUM:
                 break;
             case ARRAY:
                 Schema elementType = schema.getElementType();
-                parseSchema(elementType, schemaFieldInfos);
+                parseSchema(elementType, schemaFieldInfos, visitedRecords);
                 break;
 
             case UNION:
                 List<Schema> unionTypes = schema.getTypes();
                 for (Schema typeSchema : unionTypes) {
-                    parseSchema(typeSchema, schemaFieldInfos);
+                    parseSchema(typeSchema, schemaFieldInfos, visitedRecords);
                 }
                 break;
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
@@ -83,11 +83,8 @@ public class AvroFieldsGenerator {
 
                 String completeName = schema.getFullName();
 
-                if (visitedRecords.contains(completeName)) {
-                    // Since we are only interested in primitive data types, if we encounter a record that was already parsed it can be ignored
-                    break;
-                }
-                else {
+                // Since we are only interested in primitive data types, if we encounter a record that was already parsed it can be ignored
+                if (!visitedRecords.contains(completeName)) {
                     visitedRecords.add(completeName);
 
                     // store fields of a record.

--- a/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
+++ b/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
@@ -15,14 +15,12 @@
  */
 package com.hortonworks.registries.schemaregistry.avro;
 
-import com.hortonworks.registries.schemaregistry.SchemaFieldInfo;
 import org.apache.avro.Schema;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 public class AvroNestedCheckerTest {
 

--- a/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
+++ b/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
@@ -15,11 +15,14 @@
  */
 package com.hortonworks.registries.schemaregistry.avro;
 
+import com.hortonworks.registries.schemaregistry.SchemaFieldInfo;
 import org.apache.avro.Schema;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 public class AvroNestedCheckerTest {
 
@@ -34,25 +37,40 @@ public class AvroNestedCheckerTest {
     }
 
     @Test
-    public void testAvroFieldsGenerator_Simple() throws IOException {
-        // As long as no exceptions are thrown, this passes.
-        new AvroFieldsGenerator().generateFields(simpleNestedSchema);
+    public void testSimpleAvroFieldsGenerator() throws IOException {
+        /*
+            Should return 3 fields;
+            - SimpleRecord.id : int
+            - SimpleRecord.value : string
+            - SimpleRecord.parent : Union(null, Record(Record_B))
+         */
+        Assert.assertEquals(3 , new AvroFieldsGenerator().generateFields(simpleNestedSchema).size());
     }
 
     @Test
-    public void testAvroFieldsGenerator_Complex() throws IOException {
-        // As long as no exceptions are thrown, this passes.
-        new AvroFieldsGenerator().generateFields(complexNestedSchema);
+    public void testComplexAvroFieldsGenerator() throws IOException {
+        /*
+            Should return 8 fields;
+            - Record_A.id : int
+            - Record_A.value : string
+            - Record_A.child : Record(Record_B)
+            - Record_A.child.id : int
+            - Record_A.child.value : string
+            - Record_A.child.parent : Union(null, Record(Record_A))
+            - Record_A.arrayTest : array(Record_A)
+            - Record_A.mapTest : map(Record_A)
+         */
+        Assert.assertEquals(8 , new AvroFieldsGenerator().generateFields(complexNestedSchema).size());
     }
 
     @Test
-    public void testAvroSchemaProvider_Simple() throws IOException {
+    public void testSimpleAvroSchemaProvider() throws IOException {
         // As long as no exceptions are thrown, this passes.
         new AvroSchemaProvider().normalize(simpleNestedSchema);
     }
 
     @Test
-    public void testAvroSchemaProvider_Complex() throws IOException {
+    public void testComplexAvroSchemaProvider() throws IOException {
         // As long as no exceptions are thrown, this passes.
         new AvroSchemaProvider().normalize(complexNestedSchema);
     }

--- a/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
+++ b/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hortonworks.registries.schemaregistry.avro;
+
+import org.apache.avro.Schema;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AvroNestedCheckerTest {
+
+    private static Schema simpleNestedSchema;
+    private static Schema complexNestedSchema;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        Schema.Parser schemaParser = new Schema.Parser();
+        simpleNestedSchema = schemaParser.parse(AvroNestedCheckerTest.class.getResourceAsStream("/avro/nested/nested-simple.avsc"));
+        complexNestedSchema = schemaParser.parse(AvroNestedCheckerTest.class.getResourceAsStream("/avro/nested/nested-complex.avsc"));
+    }
+
+    @Test
+    public void testAvroFieldsGenerator_Simple() throws IOException {
+        // As long as no exceptions are thrown, this passes.
+        new AvroFieldsGenerator().generateFields(simpleNestedSchema);
+    }
+
+    @Test
+    public void testAvroFieldsGenerator_Complex() throws IOException {
+        // As long as no exceptions are thrown, this passes.
+        new AvroFieldsGenerator().generateFields(complexNestedSchema);
+    }
+
+    @Test
+    public void testAvroSchemaProvider_Simple() throws IOException {
+        // As long as no exceptions are thrown, this passes.
+        new AvroSchemaProvider().normalize(simpleNestedSchema);
+    }
+
+    @Test
+    public void testAvroSchemaProvider_Complex() throws IOException {
+        // As long as no exceptions are thrown, this passes.
+        new AvroSchemaProvider().normalize(complexNestedSchema);
+    }
+}

--- a/schema-registry/common/src/test/resources/avro/nested/nested-complex.avsc
+++ b/schema-registry/common/src/test/resources/avro/nested/nested-complex.avsc
@@ -1,0 +1,40 @@
+{
+  "namespace": "nested.complex",
+  "name": "Record_A",
+  "type": "record",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "value",
+      "type": "string"
+    },
+    {
+      "name": "child",
+      "type": {
+        "namespace": "nested.complex",
+        "name": "Record_B",
+        "type": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "int"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          },
+          {
+            "name": "parent",
+            "type": [
+              "null",
+              "Record_A"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/schema-registry/common/src/test/resources/avro/nested/nested-complex.avsc
+++ b/schema-registry/common/src/test/resources/avro/nested/nested-complex.avsc
@@ -35,6 +35,20 @@
           }
         ]
       }
+    },
+    {
+      "name": "arrayTest",
+      "type": {
+        "type": "array",
+        "items": "Record_A"
+      }
+    },
+    {
+      "name": "mapTest",
+      "type": {
+        "type": "map",
+        "values": "Record_A"
+      }
     }
   ]
 }

--- a/schema-registry/common/src/test/resources/avro/nested/nested-simple.avsc
+++ b/schema-registry/common/src/test/resources/avro/nested/nested-simple.avsc
@@ -1,0 +1,22 @@
+{
+  "namespace": "nested",
+  "name": "SimpleRecord",
+  "type": "record",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "value",
+      "type": "string"
+    },
+    {
+      "name": "parent",
+      "type": [
+        "null",
+        "SimpleRecord"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added test resources for testing nested schemas.
Added tests to make sure AvroFieldsGenerator and AvroSchemaProvider can parse nested schemas.
Added code to AvroFieldsGenerator to handle parsing nested schemas.

I'd like to fix this against v0.3.1, since we're looking at using the Hortonworks Schema Registry with NiFi, and as of this PR submission, NiFi 1.5 is compatible with v0.3.0, and it seems there was API changes in v0.4+