### PR TITLE
ISSUE-428 Lowercase mysql table names in storage initenv

### DIFF
--- a/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/initenv/mysql/MySqlDatabaseCreator.java
+++ b/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/initenv/mysql/MySqlDatabaseCreator.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 
 public class MySqlDatabaseCreator implements DatabaseCreator {
 
-    private static final String QUERY_DATABASE_TEMPLATE = "SELECT count(*) AS cnt FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name = '%s'";
+    private static final String QUERY_DATABASE_TEMPLATE = "SELECT count(*) AS cnt FROM information_schema.schemata WHERE schema_name = '%s'";
     private static final String CREATE_DATABASE_TEMPLATE = "CREATE DATABASE %s";
     private static final String[] GRANT_PRIVILEGES_TEMPLATE = {
         "GRANT ALL PRIVILEGES ON %s.* TO '%s'@'localhost'",

--- a/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/initenv/mysql/MySqlUserCreator.java
+++ b/storage/tool/src/main/java/com/hortonworks/registries/storage/tool/sql/initenv/mysql/MySqlUserCreator.java
@@ -8,7 +8,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class MySqlUserCreator implements UserCreator {
-    private static final String QUERY_USER_TEMPLATE = "SELECT count(*) AS cnt FROM MYSQL.USER WHERE USER = '%s'";
+    private static final String QUERY_USER_TEMPLATE = "SELECT count(*) AS cnt FROM mysql.user WHERE user = '%s'";
     private static final String[] CREATE_USER_TEMPLATE = {
             "create user '%s'@'localhost' IDENTIFIED BY '%s'",
             "create user '%s'@'%%' IDENTIFIED BY '%s'"


### PR DESCRIPTION
Manually tested from both MySQL 5.7 in MacOS and MySQL 5.6 in Linux.

This closes #428 