### PR TITLE
JDBC HA Leadership Participant Implementation

### DIFF
--- a/common/src/main/java/com/hortonworks/registries/common/ha/LeadershipParticipant.java
+++ b/common/src/main/java/com/hortonworks/registries/common/ha/LeadershipParticipant.java
@@ -49,9 +49,9 @@ public interface LeadershipParticipant {
      * Exits from leadership participation. This may throw an Exception if the current latch is not yet started
      * or it has already been closed.
      *
-     * @throws IOException if any IO related errors occur.
+     * @throws Exception if any errors occur.
      */
-    void exitFromLeaderParticipation() throws IOException;
+    void exitFromLeaderParticipation() throws Exception;
 
     /**
      * Returns true if the current participant is a leader
@@ -59,10 +59,10 @@ public interface LeadershipParticipant {
     boolean isLeader();
 
     /**
-     * Closes the underlying ZK client resources.
+     * Closes the underlying client resources.
      *
-     * @throws IOException if any io errors occurred during this operation.
+     * @throws Exception if any errors occur.
      */
-    void close() throws IOException;
+    void close() throws Exception;
 
 }

--- a/conf/registry-mysql-example.yaml
+++ b/conf/registry-mysql-example.yaml
@@ -38,7 +38,7 @@ servletFilters:
      forwardPaths: "/api/v1/confluent,/subjects/*,/schemas/ids/*"
      redirectPaths: "/ui/,/"
 
-# HA configuration
+# HA configuration - ZK
 #haConfig:
 #  className: com.hortonworks.registries.ha.zk.ZKLeadershipParticipant
 #  config:
@@ -51,6 +51,19 @@ servletFilters:
 #    retry.limit: 5
 #    retry.base.sleep.time.ms: 1000
 #    retry.max.sleep.time.ms: 5000
+
+# HA configuration - MySQL
+#haConfig:
+#  className: com.hortonworks.registries.ha.jdbc.JdbcLeadershipParticipant
+#  config:
+#    db.type: "mysql"
+#    table: "lock_table"
+#    timeout: 5000
+#    db.properties:
+#      dataSourceClassName: "com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
+#      dataSource.url: "jdbc:mysql://localhost/schema_registry"
+#      dataSource.user: "registry_user"
+#      dataSource.password: "registry_password"
 
 # Filesystem based jar storage
 fileStorageConfiguration:

--- a/conf/registry-postgres-example.yaml
+++ b/conf/registry-postgres-example.yaml
@@ -38,7 +38,7 @@ servletFilters:
      forwardPaths: "/api/v1/confluent,/subjects/*,/schemas/ids/*"
      redirectPaths: "/ui/,/"
 
-# HA configuration
+# HA configuration - ZK
 #haConfig:
 #  className: com.hortonworks.registries.ha.zk.ZKLeadershipParticipant
 #  config:
@@ -51,6 +51,19 @@ servletFilters:
 #    retry.limit: 5
 #    retry.base.sleep.time.ms: 1000
 #    retry.max.sleep.time.ms: 5000
+
+# HA configuration - Postgres
+#haConfig:
+#  className: com.hortonworks.registries.ha.jdbc.JdbcLeadershipParticipant
+#  config:
+#    db.type: "postgresql"
+#    table: "lock_table"
+#    timeout: 5000
+#    db.properties:
+#      dataSourceClassName: "org.postgresql.ds.PGSimpleDataSource"
+#      dataSource.url: "jdbc:postgresql://localhost/schema_registry"
+#      dataSource.user: "postgres"
+#      dataSource.password: "postgres"
 
 # Filesystem based jar storage
 fileStorageConfiguration:

--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -131,6 +131,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2database.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/webservice/src/main/java/com/hortonworks/registries/ha/jdbc/JdbcLeadershipParticipant.java
+++ b/webservice/src/main/java/com/hortonworks/registries/ha/jdbc/JdbcLeadershipParticipant.java
@@ -1,0 +1,219 @@
+package com.hortonworks.registries.ha.jdbc;
+
+import com.google.common.base.Preconditions;
+import com.hortonworks.registries.common.ha.LeadershipParticipant;
+import com.hortonworks.registries.storage.impl.jdbc.provider.QueryExecutorFactory;
+import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.QueryExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * {@link LeadershipParticipant} implementation for databases accessible through JDBC (like MySQL or PostgreSQL).
+ *
+ * It uses a table to manage the leader election. Taking advantage of primary key collision, we can handle only one
+ * leader at the same time.
+ * Then, using upserts, we can handle to update the timeout if we are the leader, or taking leadership if already timed out.
+ *
+ * Unfortunately, there is no standard SQL statement implemented in major vendors to handle upserts properly, so we need
+ * to handle this logic separatelly across different DB types. Right now only MySQL and PostgreSQL implementations are
+ * provided. Oracle is not provided as it is more complex to set up a properly environment to test it (Licenses and stuff)
+ *
+ * To check who owns the lock of release it, is as simple as a select query to retrieve the row and delete the row itself.
+ *
+ * When deleting the row, the next one who tries to achieve leadership will succeed.
+ *
+ * This approach is preferred instead of using user-defined locks (i.e. GET_LOCK from MySQL or pg_advisory_lock from
+ * PostgreSQL, because:
+ * - We must allocate a dedicated connection that lives for the duration of the lock (until the application stops)
+ * - This doesn't play too well with  typical connection pools
+ * - There is no visibility into "who" is holding the lock. So, we would still to store the server url of the leader
+ *   somewhere else, ending up with a similar complexity solution.
+ * - If the application hangs (but does not die or close the connection), the lock is still being held. There is no
+ *   "keepalive" or "timeout" requirement on the lock's side.
+ *
+ */
+public class JdbcLeadershipParticipant implements LeadershipParticipant {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcLeadershipParticipant.class);
+
+    public static final String DB_TYPE_CONFIG = "db.type";
+    public static final String DB_PROPERTIES_CONFIG = "db.properties";
+    public static final String TABLE_NAME_CONFIG = "table";
+    public static final String LOCK_ID_CONFIG = "lock";
+    public static final String TIMEOUT_CONFIG = "timeout";
+    public static final String REFRESH_CONFIG = "refresh";
+
+    public static final int DEFAULT_LOCK_ID = 1;
+    public static final long DEFAULT_TIMEOUT = 5000;
+
+    private static final int MAX_RETRIES = 5;
+
+    private static final String CREATE_STATEMENT =
+            "CREATE TABLE IF NOT EXISTS %s (" +
+                    "  lock_id INTEGER NOT NULL," +
+                    "  server_url VARCHAR(256) NOT NULL," +
+                    "  last_seen_active TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
+                    "  PRIMARY KEY (lock_id)" +
+                    ")";
+
+    private static final String LOCK_STATEMENT_MYSQL =
+            "INSERT INTO %s (lock_id, server_url, last_seen_active) VALUES (?, ?, CURRENT_TIMESTAMP) " +
+                    "ON DUPLICATE KEY UPDATE " +
+                    "    server_url = CASE WHEN last_seen_active < DATEADD('MILLISECOND', ?, CURRENT_TIMESTAMP) THEN VALUES(server_url) ELSE server_url END," +
+                    "    last_seen_active = CASE WHEN server_url = VALUES(server_url) THEN VALUES(last_seen_active) ELSE last_seen_active END";
+
+    private static final String LOCK_STATEMENT_POSTGRESQL =
+            "INSERT INTO %s AS ORIGINAL (lock_id, server_url, last_seen_active) VALUES (?, ?, CURRENT_TIMESTAMP) " +
+                    "ON CONFLICT (lock_id) DO UPDATE SET " +
+                    "    server_url = CASE WHEN ORIGINAL.last_seen_active < CURRENT_TIMESTAMP + ? * INTERVAL '1 milliseconds' THEN EXCLUDED.server_url ELSE ORIGINAL.server_url END," +
+                    "    last_seen_active = CASE WHEN ORIGINAL.server_url = EXCLUDED.server_url THEN EXCLUDED.last_seen_active ELSE ORIGINAL.last_seen_active END";
+
+    private static final String GET_STATEMENT =
+            "SELECT server_url AS leader FROM %s WHERE lock_id = ?";
+
+    private static final String UNLOCK_STATEMENT =
+            "DELETE FROM %s WHERE lock_id = ?";
+
+    private Timer executor;
+
+    private String tableName;
+    private int lock;
+    private int timeout;
+    private int refresh;
+
+    private String dbType;
+    private QueryExecutor queryExecutor;
+    private String serverUrl;
+
+    @Override
+    public void init(Map<String, Object> config, String participantId) {
+        Preconditions.checkNotNull(participantId, "participantId can not be null");
+        Preconditions.checkNotNull(config, "conf can not be null");
+        if(!config.containsKey(DB_TYPE_CONFIG)) {
+            throw new IllegalArgumentException("db.type should be set on jdbc properties");
+        }
+
+        LOG.info("Received configuration : [{}]", config);
+
+        this.serverUrl = participantId;
+
+        this.dbType = ((String) config.get(DB_TYPE_CONFIG)).toLowerCase();
+        Map<String, Object> dbProperties = (Map<String, Object>) config.get(DB_PROPERTIES_CONFIG);
+        this.queryExecutor = QueryExecutorFactory.get(dbType, dbProperties);
+
+        this.tableName = (String) config.get(TABLE_NAME_CONFIG);
+        this.lock = (Integer) config.getOrDefault(LOCK_ID_CONFIG, DEFAULT_LOCK_ID);
+        this.timeout = (Integer) config.getOrDefault(TIMEOUT_CONFIG, DEFAULT_TIMEOUT);
+        this.refresh = (Integer) config.getOrDefault(REFRESH_CONFIG, this.timeout/4);
+
+        initDB();
+    }
+
+    private void initDB() {
+        try (Connection connection = queryExecutor.getConnection();
+             Statement statement = connection.createStatement())
+        {
+            statement.executeUpdate(String.format(CREATE_STATEMENT, tableName));
+        } catch (SQLException e) {
+            LOG.error("Cannot create lock table", e);
+        }
+    }
+
+    @Override
+    public void participateForLeadership() throws Exception{
+        // Blockingly participate for leadership the first time
+        updateParticipationForLeadership();
+
+        // Schedule next updates
+        this.executor = new Timer();
+        this.executor.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    updateParticipationForLeadership();
+                } catch (SQLException e) {
+                    LOG.error("Cannot update participation for leadership", e);
+                }
+            }
+        }, refresh, refresh);
+    }
+
+    private void updateParticipationForLeadership() throws SQLException {
+        try (Connection connection = queryExecutor.getConnection();
+             PreparedStatement statement = connection.prepareStatement(String.format(getLockStatement(), tableName)))
+        {
+            statement.setInt(1, lock);
+            statement.setString(2, serverUrl);
+            statement.setInt(3, -timeout);
+
+            statement.executeUpdate();
+        }
+    }
+
+    private String getLockStatement() {
+        switch (dbType) {
+            case "mysql": return LOCK_STATEMENT_MYSQL;
+            case "postgresql": return LOCK_STATEMENT_POSTGRESQL;
+            default: throw new IllegalArgumentException("Unsupported storage provider type: " + dbType);
+        }
+    }
+
+    @Override
+    public String getCurrentLeader() throws Exception {
+        for (int retries = 0; retries < MAX_RETRIES; retries++) {
+            try (Connection connection = queryExecutor.getConnection();
+                 PreparedStatement statement = connection.prepareStatement(String.format(GET_STATEMENT, tableName)))
+            {
+                statement.setInt(1, lock);
+
+                ResultSet resultSet = statement.executeQuery();
+                if (resultSet.next()) {
+                    return resultSet.getString(1);
+                } else {
+                    // This may happen if the leader is gone, and nobody tried to get leadership yet. So we will try it and check it again
+                    updateParticipationForLeadership();
+                }
+            }
+        }
+        throw new IllegalStateException("Could not get current leader");
+    }
+
+    @Override
+    public boolean isLeader() {
+        try {
+            String currentLeader = getCurrentLeader();
+            return currentLeader.equals(this.serverUrl);
+        } catch (Exception e) {
+            LOG.warn("Could not deterime if leader, assuming not", e);
+            return false;
+        }
+    }
+
+    @Override
+    public void exitFromLeaderParticipation() throws Exception {
+        this.executor.cancel();
+        this.executor = null;
+        if (isLeader()) {
+            try (Connection connection = queryExecutor.getConnection();
+                 PreparedStatement statement = connection.prepareStatement(String.format(UNLOCK_STATEMENT, tableName)))
+            {
+                statement.setInt(1, lock);
+                statement.executeUpdate();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        if (this.executor != null) {
+            executor.cancel();
+            executor = null;
+        }
+        this.queryExecutor.cleanup();
+    }
+
+}

--- a/webservice/src/test/java/com/hortonworks/registries/ha/jdbc/JdbcLeadershipParticipantTest.java
+++ b/webservice/src/test/java/com/hortonworks/registries/ha/jdbc/JdbcLeadershipParticipantTest.java
@@ -1,0 +1,150 @@
+package com.hortonworks.registries.ha.jdbc;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base test for specific JDBC implementations.
+ * Sadly, we can only test it for MySQL, because using H2 with compatibility mode doesn't support the syntax we need for
+ * PostgreSQL.
+ * We should embed the database with the test, this causing too much complexity and a waste of time and resources when
+ * building.
+ * It has been tested against local instance of PostgreSQL to check the correctness of the solution and syntax, but will
+ * not be tested on each build. So, if you modify the queries, make sure to test it properly.
+ */
+public abstract class JdbcLeadershipParticipantTest {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcLeadershipParticipantTest.class);
+
+    private static final String TABLE_NAME = "lock_table";
+    private static final int DEFAULT_TIMEOUT = 1000;
+
+    abstract String getDbType();
+
+    @Before
+    public void clearDatabase() throws SQLException {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL(getDataSourceUrl(getDbType()));
+
+        try (Connection c = dataSource.getConnection(); Statement s = c.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS "+TABLE_NAME);
+        }
+    }
+
+    @Test
+    public void singleParticipant() throws Exception {
+        Map<String, Object> conf = createConf(getDbType());
+
+        String participant = "only-me";
+
+        JdbcLeadershipParticipant jdbcLeadershipParticipant = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant.init(conf, participant);
+
+        jdbcLeadershipParticipant.participateForLeadership();
+
+        Assert.assertTrue(jdbcLeadershipParticipant.isLeader());
+    }
+
+    @Test
+    public void twoParticipants() throws Exception {
+        Map<String, Object> conf = createConf(getDbType());
+
+        String participant1 = "foo-1";
+        JdbcLeadershipParticipant jdbcLeadershipParticipant1 = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant1.init(conf, participant1);
+
+        String participant2 = "foo-2";
+        JdbcLeadershipParticipant jdbcLeadershipParticipant2 = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant2.init(conf, participant2);
+
+        jdbcLeadershipParticipant1.participateForLeadership(); // First to ask for leadership
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader());
+        jdbcLeadershipParticipant2.participateForLeadership();
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader());
+        Assert.assertFalse(jdbcLeadershipParticipant2.isLeader());
+
+        jdbcLeadershipParticipant1.exitFromLeaderParticipation(); // Current leader exit
+        Thread.sleep(DEFAULT_TIMEOUT); // Wait for reelection
+        Assert.assertFalse(jdbcLeadershipParticipant1.isLeader());
+        Assert.assertTrue(jdbcLeadershipParticipant2.isLeader());
+    }
+
+    @Test
+    public void twoParticipantsReparticipate() throws Exception {
+        Map<String, Object> conf = createConf(getDbType());
+
+        String participant1 = "foo-1";
+        JdbcLeadershipParticipant jdbcLeadershipParticipant1 = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant1.init(conf, participant1);
+
+        String participant2 = "foo-2";
+        JdbcLeadershipParticipant jdbcLeadershipParticipant2 = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant2.init(conf, participant2);
+
+        jdbcLeadershipParticipant1.participateForLeadership(); // First to ask for leadership
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader());
+        jdbcLeadershipParticipant2.participateForLeadership();
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader());
+        Assert.assertFalse(jdbcLeadershipParticipant2.isLeader());
+
+        jdbcLeadershipParticipant1.exitFromLeaderParticipation();
+        Thread.sleep(DEFAULT_TIMEOUT); // Wait for reelection
+        jdbcLeadershipParticipant1.participateForLeadership();
+        Assert.assertFalse(jdbcLeadershipParticipant1.isLeader());
+        Assert.assertTrue(jdbcLeadershipParticipant2.isLeader());
+    }
+
+    @Test
+    public void twoParticipantsReparticipateWithoutWait() throws Exception {
+        Map<String, Object> conf = createConf(getDbType(), 42000); // Huge timeout to avoid automatic reelection
+
+        String participant1 = "foo-1";
+        JdbcLeadershipParticipant jdbcLeadershipParticipant1 = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant1.init(conf, participant1);
+
+        String participant2 = "foo-2";
+        JdbcLeadershipParticipant jdbcLeadershipParticipant2 = new JdbcLeadershipParticipant();
+        jdbcLeadershipParticipant2.init(conf, participant2);
+
+        jdbcLeadershipParticipant1.participateForLeadership(); // First to ask for leadership
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader());
+        jdbcLeadershipParticipant2.participateForLeadership();
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader());
+        Assert.assertFalse(jdbcLeadershipParticipant2.isLeader());
+
+        jdbcLeadershipParticipant1.exitFromLeaderParticipation();
+        jdbcLeadershipParticipant1.participateForLeadership();
+        Assert.assertTrue(jdbcLeadershipParticipant1.isLeader()); // The first one to ask for who is the leader will get it
+        Assert.assertFalse(jdbcLeadershipParticipant2.isLeader());
+    }
+
+    private Map<String, Object> createConf(String dbType) {
+        return createConf(dbType, DEFAULT_TIMEOUT);
+    }
+
+    private Map<String, Object> createConf(String dbType, int timeout) {
+        Map<String, Object> dbProperties = new HashMap<>();
+        dbProperties.put("dataSourceClassName", "org.h2.jdbcx.JdbcDataSource");
+        dbProperties.put("dataSource.url", getDataSourceUrl(dbType));
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("table", TABLE_NAME);
+        conf.put("timeout", timeout);
+        conf.put("db.properties", dbProperties);
+        conf.put("db.type", dbType);
+        return conf;
+    }
+
+    String getDataSourceUrl(String dbType) {
+        return "jdbc:h2:mem:test;MODE="+dbType+";DATABASE_TO_UPPER=false;DB_CLOSE_ON_EXIT=FALSE";
+    }
+
+}

--- a/webservice/src/test/java/com/hortonworks/registries/ha/jdbc/MysqlLeadershipParticipantTest.java
+++ b/webservice/src/test/java/com/hortonworks/registries/ha/jdbc/MysqlLeadershipParticipantTest.java
@@ -1,0 +1,8 @@
+package com.hortonworks.registries.ha.jdbc;
+
+public class MysqlLeadershipParticipantTest extends JdbcLeadershipParticipantTest {
+    @Override
+    String getDbType() {
+        return "MySQL";
+    }
+}


### PR DESCRIPTION
Although it really makes sense to use ZK to coordinate HA leadership, taking into consideration we already need it for Kafka, sometimes we may not have access to ZK, or we may have a shared registry across different environments and it doesn't make sense to tie it to any specific one.
Taking into consideration that we already have a Storage dependency on MySQL or PostgreSQL, it makes sense to also coordinate HA leadership through it.
This implementation uses a table to manage the leader election. Taking advantage of primary key collision, we can handle only one leader at the same time.
More details on the code comments