### PR TITLE
ISSUE-467 UI fails to load schemas without schema versions

### DIFF
--- a/webservice/src/main/resources/app/scripts/components/SchemaDetail.jsx
+++ b/webservice/src/main/resources/app/scripts/components/SchemaDetail.jsx
@@ -139,8 +139,8 @@ export default class SchemaDetail extends Component{
     schema.collapsed = !s.collapsed;
     obj.schemaData = schemaData;
     SchemaRegistryContainer.setState(obj);*/
-    const {selectedBranch, collapsed} = this.state;
-    this.setState({collapsed : selectedBranch ? !collapsed : true});
+    const {collapsed} = this.state;
+    this.setState({collapsed : !collapsed });
   }
   handleOnEnter(s){
     this.setState({renderCodemirror: true});
@@ -155,7 +155,7 @@ export default class SchemaDetail extends Component{
   }
   handleAddVersion (schemaObj) {
     const {selectedBranch, currentVersion} = this.state;
-    let obj = _.find(selectedBranch.schemaVersionInfos, {version: currentVersion});
+    let obj = selectedBranch ? _.find(selectedBranch.schemaVersionInfos, {version: currentVersion}) : undefined;
     this.schemaObj = {
       schemaName: schemaObj.schemaMetadata.name,
       description: obj ? obj.description : '',
@@ -184,7 +184,7 @@ export default class SchemaDetail extends Component{
             /*const {SchemaRegistryContainer} = this.context;
             SchemaRegistryContainer.fetchData();*/
             const {selectedBranch} = this.state;
-            this.fetchAndSelectBranch(selectedBranch.schemaBranch.name);
+            this.fetchAndSelectBranch(selectedBranch ? selectedBranch.schemaBranch.name : "MASTER");
             let msg = "Version added successfully";
             if (this.state.modalTitle === 'Edit Version') {
               msg = "Version updated successfully";
@@ -382,7 +382,7 @@ export default class SchemaDetail extends Component{
       theme: 'default no-cursor schema-editor'
     };
 
-    var versionObj = selectedBranch ? _.find(selectedBranch.schemaVersionInfos, {version: currentVersion}) : {};
+    var versionObj = selectedBranch ? _.find(selectedBranch.schemaVersionInfos, {version: currentVersion}) : null;
     var sortedVersions =  selectedBranch ? Utils.sortArray(selectedBranch.schemaVersionInfos.slice(), 'version', false) : [];
 
     const expandButton = ' ' || <button key="e.3" type="button" className="btn btn-link btn-expand-schema" onClick={this.handleExpandView.bind(this, s)}>
@@ -395,7 +395,7 @@ export default class SchemaDetail extends Component{
         headerRole="tabpanel"
         key={name}
         collapsible
-        expanded={selectedBranch ? (collapsed ? false : true) : false}
+        expanded={collapsed ? false : true}
         onSelect={this.handleSelect.bind(this, s)}
         onEntered={this.handleOnEnter.bind(this, s)}
         onExited={this.handleOnExit.bind(this, s)}
@@ -501,7 +501,7 @@ export default class SchemaDetail extends Component{
           <div className="row">
           {evolve ? ([
             <div className="col-sm-3" key="v.k.1">
-              <h6 className="schema-th">Description</h6>
+              <h6 className="schema-th text-danger">There is no version associated for this particular schema.</h6>
               <p></p>
             </div>,
             <div className="col-sm-6" key="v.k.2">
@@ -524,9 +524,6 @@ export default class SchemaDetail extends Component{
                 </div>
               </div>)
               }
-            </div>,
-            <div className="col-sm-3" key="v.k.3">
-              <h6 className="schema-th">Change Log</h6>
             </div>])
             : <div style={{'textAlign': 'center'}}>NO DATA FOUND</div>
             }

--- a/webservice/src/main/resources/app/scripts/components/SchemaDetail.jsx
+++ b/webservice/src/main/resources/app/scripts/components/SchemaDetail.jsx
@@ -52,7 +52,10 @@ export default class SchemaDetail extends Component{
     const selectedBranch = _.find(schema.schemaBranches, (branch) => {
       return branch.schemaBranch.name == 'MASTER';
     });
-    const currentVersion = Utils.sortArray(selectedBranch.schemaVersionInfos.slice(), 'timestamp', false)[0].version;
+    let currentVersion = 0;
+    if(selectedBranch){
+      currentVersion = Utils.sortArray(selectedBranch.schemaVersionInfos.slice(), 'timestamp', false)[0].version;
+    }
     this.state = {
       collapsed: true,
       renderCodemirror: false,
@@ -136,8 +139,8 @@ export default class SchemaDetail extends Component{
     schema.collapsed = !s.collapsed;
     obj.schemaData = schemaData;
     SchemaRegistryContainer.setState(obj);*/
-    const {collapsed} = this.state;
-    this.setState({collapsed : !collapsed});
+    const {selectedBranch, collapsed} = this.state;
+    this.setState({collapsed : selectedBranch ? !collapsed : true});
   }
   handleOnEnter(s){
     this.setState({renderCodemirror: true});
@@ -305,7 +308,7 @@ export default class SchemaDetail extends Component{
     var btnClass = this.getBtnClass(compatibility);
     var iconClass = this.getIconClass(compatibility);
     // var totalVersions = s.versions.length;
-    
+
     var header = (
       <div>
         <span className={`hb ${btnClass} schema-status-icon`}><i className={iconClass}></i></span>
@@ -366,7 +369,7 @@ export default class SchemaDetail extends Component{
     const {selectedBranch, collapsed, renderCodemirror, currentVersion} = this.state;
     const s = schema;
     const {name, evolve} = s.schemaMetadata;
-    const currentBranchName = selectedBranch.schemaBranch.name;
+    const currentBranchName = selectedBranch ? selectedBranch.schemaBranch.name : "MASTER";
     const enabledStateId = StateMachine.getStateByName('Enabled').id;
 
     const jsonoptions = {
@@ -379,8 +382,8 @@ export default class SchemaDetail extends Component{
       theme: 'default no-cursor schema-editor'
     };
 
-    var versionObj = _.find(selectedBranch.schemaVersionInfos, {version: currentVersion});
-    var sortedVersions =  Utils.sortArray(selectedBranch.schemaVersionInfos.slice(), 'version', false);
+    var versionObj = selectedBranch ? _.find(selectedBranch.schemaVersionInfos, {version: currentVersion}) : {};
+    var sortedVersions =  selectedBranch ? Utils.sortArray(selectedBranch.schemaVersionInfos.slice(), 'version', false) : [];
 
     const expandButton = ' ' || <button key="e.3" type="button" className="btn btn-link btn-expand-schema" onClick={this.handleExpandView.bind(this, s)}>
       <i className="fa fa-arrows-alt"></i>
@@ -392,7 +395,7 @@ export default class SchemaDetail extends Component{
         headerRole="tabpanel"
         key={name}
         collapsible
-        expanded={collapsed ? false : true}
+        expanded={selectedBranch ? (collapsed ? false : true) : false}
         onSelect={this.handleSelect.bind(this, s)}
         onEntered={this.handleOnEnter.bind(this, s)}
         onExited={this.handleOnExit.bind(this, s)}

--- a/webservice/src/main/resources/app/scripts/containers/Registry-Services/SchemaRegistry/SchemaVersionForm.jsx
+++ b/webservice/src/main/resources/app/scripts/containers/Registry-Services/SchemaRegistry/SchemaVersionForm.jsx
@@ -122,10 +122,10 @@ export default class SchemaVersionForm extends Component {
       schemaText,
       description
     };
-    return SchemaREST.getCompatibility(this.props.schemaObj.schemaName, {body: JSON.stringify(JSON.parse(schemaText))})
+    return SchemaREST.getCompatibility(schemaObj.schemaName, {body: JSON.stringify(JSON.parse(schemaText))})
       .then((result)=>{
         if(result.compatible){
-          return SchemaREST.postVersion(this.props.schemaObj.schemaName, {body: JSON.stringify(data)}, schemaObj.branch.schemaBranch.name);
+          return SchemaREST.postVersion(schemaObj.schemaName, {body: JSON.stringify(data)}, schemaObj.branch ? schemaObj.branch.schemaBranch.name : "MASTER");
         } else {
           return result;
         }


### PR DESCRIPTION
If no schema versions, the user cannot expand the panel nor add another version from the UI.
Either add version directly through API's from the backend or create a new schema altogether.

@satishd - Please let me know if this behavior works in general since from UI there's rare chance that the user might fall into this issue or would you prefer that we should revisit the flow for such cases.