### PR TITLE
ISSUE-470 hibernate-validator updated with 5.4.2 which is in sync with drop-wizard-s dependency

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>registry-common</artifactId>
 
     <properties>
-        <hibernate-validator.version>5.2.5.Final</hibernate-validator.version>
+        <hibernate-validator.version>5.4.2.Final</hibernate-validator.version>
     </properties>
 
     <dependencies>
@@ -60,6 +60,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
- hibernate-validator updated with 5.4.2 which is in sync with drop-wizard-s dependency
-   Excluded jsp-api to avoid javax.el lib conflicts