### PR TITLE
ISSUE-485 Fix adding large schema text for oracle

### DIFF
--- a/registry-dist/VERSION
+++ b/registry-dist/VERSION
@@ -1,0 +1,6 @@
+#Created by build system. Do not modify
+#Mon Aug 13 23:06:05 IST 2018
+version=0.5.1-SNAPSHOT
+revision=cf2c6e1cf0021d4440ceb53a46a6c3910907bba4
+name=Registry Binary Distribution
+timestamp=1534181765088

--- a/registry-dist/VERSION
+++ b/registry-dist/VERSION
@@ -1,6 +1,0 @@
-#Created by build system. Do not modify
-#Mon Aug 13 23:06:05 IST 2018
-version=0.5.1-SNAPSHOT
-revision=cf2c6e1cf0021d4440ceb53a46a6c3910907bba4
-name=Registry Binary Distribution
-timestamp=1534181765088

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionLifecycleManager.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionLifecycleManager.java
@@ -847,7 +847,7 @@ public class SchemaVersionLifecycleManager {
             throw new SchemaNotFoundException("No Schema version exists with id " + schemaVersionId);
         }
         versionedSchema.setState(stateId);
-        storageManager.addOrUpdate(versionedSchema);
+        storageManager.update(versionedSchema);
 
         // invalidate schema version from cache
         SchemaVersionInfoCache.Key schemaVersionCacheKey = SchemaVersionInfoCache.Key.of(new SchemaIdVersion(schemaVersionId));

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleUpdateQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleUpdateQuery.java
@@ -20,6 +20,7 @@ import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.exception.OracleQueryException;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractStorableUpdateQuery;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -62,8 +63,10 @@ public class OracleUpdateQuery extends AbstractStorableUpdateQuery {
     }
 
     private Map<Schema.Field, Object> createWhereClauseColumnToValueMap() {
-        Map<Schema.Field, Object> bindingMap = getBindings().stream().
-                collect(Collectors.toMap(keyValuePair -> keyValuePair.getKey(), keyValuePair -> keyValuePair.getValue()));
+        Map<Schema.Field, Object> bindingMap = new HashMap<>();
+        for(Pair<Schema.Field, Object> fieldObjectPair: getBindings()){
+            bindingMap.put(fieldObjectPair.getKey(),fieldObjectPair.getValue());
+        }
         return whereFields.stream().collect(Collectors.toMap(f -> f, f -> bindingMap.get(f)));
     }
 }


### PR DESCRIPTION
Fix ORA-01461 (https://support.oracle.com/knowledge/Middleware/1620109_1.html) when using the "merge" command which is used in addOrUpdate. addOrUpdate is used while updating schemaVersionStorable's state after persisting schemaStateStorable, so instead of using addOrUpdate use update as it serves the same purpose.