### PR TITLE
HOTFIX : Work around JDBC bug (ORA-01461) while inserting a schema text larger than 4k characters

### DIFF
--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroFieldsGenerator.java
@@ -21,7 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -46,13 +48,15 @@ public class AvroFieldsGenerator {
             LOG.debug("Schema full name: [{}]", fullName);
 
             List<Schema.Field> fields = schema.getFields();
+            Set<String> visitedRecords = new HashSet<>();
+            visitedRecords.add(schema.getFullName());
             for (Schema.Field field : fields) {
-                parseField(field, schemaFieldInfos);
+                parseField(field, schemaFieldInfos, visitedRecords);
             }
         }
     }
 
-    private void parseField(Schema.Field field, List<SchemaFieldInfo> schemaFieldInfos) {
+    private void parseField(Schema.Field field, List<SchemaFieldInfo> schemaFieldInfos, Set<String> visitedRecords) {
         Schema schema = field.schema();
         Schema.Type type = schema.getType();
         String name = field.name();
@@ -67,36 +71,44 @@ public class AvroFieldsGenerator {
         schemaFieldInfos.add(new SchemaFieldInfo(namespace, name, type.name()));
 
         // todo check whether fields should be mapped to the root schema.
-        parseSchema(schema, schemaFieldInfos);
+        parseSchema(schema, schemaFieldInfos, visitedRecords);
     }
 
-    private void parseSchema(Schema schema, List<SchemaFieldInfo> schemaFieldInfos) {
+    private void parseSchema(Schema schema, List<SchemaFieldInfo> schemaFieldInfos, Set<String> visitedRecords) {
         Schema.Type type = schema.getType();
         LOG.debug("Visiting type: [{}]", type);
 
         switch (type) {
             case RECORD:
-                // store fields of a record.
-                List<Schema.Field> fields = schema.getFields();
-                for (Schema.Field recordField : fields) {
-                    parseField(recordField, schemaFieldInfos);
+
+                String completeName = schema.getFullName();
+
+                // Since we are only interested in primitive data types, if we encounter a record that was already parsed it can be ignored
+                if (!visitedRecords.contains(completeName)) {
+                    visitedRecords.add(completeName);
+
+                    // store fields of a record.
+                    List<Schema.Field> fields = schema.getFields();
+                    for (Schema.Field recordField : fields) {
+                        parseField(recordField, schemaFieldInfos, visitedRecords);
+                    }
                 }
                 break;
             case MAP:
                 Schema valueTypeSchema = schema.getValueType();
-                parseSchema(valueTypeSchema, schemaFieldInfos);
+                parseSchema(valueTypeSchema, schemaFieldInfos, visitedRecords);
                 break;
             case ENUM:
                 break;
             case ARRAY:
                 Schema elementType = schema.getElementType();
-                parseSchema(elementType, schemaFieldInfos);
+                parseSchema(elementType, schemaFieldInfos, visitedRecords);
                 break;
 
             case UNION:
                 List<Schema> unionTypes = schema.getTypes();
                 for (Schema typeSchema : unionTypes) {
-                    parseSchema(typeSchema, schemaFieldInfos);
+                    parseSchema(typeSchema, schemaFieldInfos, visitedRecords);
                 }
                 break;
 

--- a/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
+++ b/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroNestedCheckerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hortonworks.registries.schemaregistry.avro;
+
+import org.apache.avro.Schema;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AvroNestedCheckerTest {
+
+    private static Schema simpleNestedSchema;
+    private static Schema complexNestedSchema;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        Schema.Parser schemaParser = new Schema.Parser();
+        simpleNestedSchema = schemaParser.parse(AvroNestedCheckerTest.class.getResourceAsStream("/avro/nested/nested-simple.avsc"));
+        complexNestedSchema = schemaParser.parse(AvroNestedCheckerTest.class.getResourceAsStream("/avro/nested/nested-complex.avsc"));
+    }
+
+    @Test
+    public void testSimpleAvroFieldsGenerator() throws IOException {
+        /*
+            Should return 3 fields;
+            - SimpleRecord.id : int
+            - SimpleRecord.value : string
+            - SimpleRecord.parent : Union(null, Record(Record_B))
+         */
+        Assert.assertEquals(3 , new AvroFieldsGenerator().generateFields(simpleNestedSchema).size());
+    }
+
+    @Test
+    public void testComplexAvroFieldsGenerator() throws IOException {
+        /*
+            Should return 8 fields;
+            - Record_A.id : int
+            - Record_A.value : string
+            - Record_A.child : Record(Record_B)
+            - Record_A.child.id : int
+            - Record_A.child.value : string
+            - Record_A.child.parent : Union(null, Record(Record_A))
+            - Record_A.arrayTest : array(Record_A)
+            - Record_A.mapTest : map(Record_A)
+         */
+        Assert.assertEquals(8 , new AvroFieldsGenerator().generateFields(complexNestedSchema).size());
+    }
+
+    @Test
+    public void testSimpleAvroSchemaProvider() throws IOException {
+        // As long as no exceptions are thrown, this passes.
+        new AvroSchemaProvider().normalize(simpleNestedSchema);
+    }
+
+    @Test
+    public void testComplexAvroSchemaProvider() throws IOException {
+        // As long as no exceptions are thrown, this passes.
+        new AvroSchemaProvider().normalize(complexNestedSchema);
+    }
+}

--- a/schema-registry/common/src/test/resources/avro/nested/nested-complex.avsc
+++ b/schema-registry/common/src/test/resources/avro/nested/nested-complex.avsc
@@ -1,0 +1,54 @@
+{
+  "namespace": "nested.complex",
+  "name": "Record_A",
+  "type": "record",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "value",
+      "type": "string"
+    },
+    {
+      "name": "child",
+      "type": {
+        "namespace": "nested.complex",
+        "name": "Record_B",
+        "type": "record",
+        "fields": [
+          {
+            "name": "id",
+            "type": "int"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          },
+          {
+            "name": "parent",
+            "type": [
+              "null",
+              "Record_A"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "arrayTest",
+      "type": {
+        "type": "array",
+        "items": "Record_A"
+      }
+    },
+    {
+      "name": "mapTest",
+      "type": {
+        "type": "map",
+        "values": "Record_A"
+      }
+    }
+  ]
+}

--- a/schema-registry/common/src/test/resources/avro/nested/nested-simple.avsc
+++ b/schema-registry/common/src/test/resources/avro/nested/nested-simple.avsc
@@ -1,0 +1,22 @@
+{
+  "namespace": "nested",
+  "name": "SimpleRecord",
+  "type": "record",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int"
+    },
+    {
+      "name": "value",
+      "type": "string"
+    },
+    {
+      "name": "parent",
+      "type": [
+        "null",
+        "SimpleRecord"
+      ]
+    }
+  ]
+}

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionLifecycleManager.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionLifecycleManager.java
@@ -852,7 +852,7 @@ public class SchemaVersionLifecycleManager {
             throw new SchemaNotFoundException("No Schema version exists with id " + schemaVersionId);
         }
         versionedSchema.setState(stateId);
-        storageManager.addOrUpdate(versionedSchema);
+        storageManager.update(versionedSchema);
 
         // invalidate schema version from cache
         SchemaVersionInfoCache.Key schemaVersionCacheKey = SchemaVersionInfoCache.Key.of(new SchemaIdVersion(schemaVersionId));

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleUpdateQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleUpdateQuery.java
@@ -20,6 +20,7 @@ import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.exception.OracleQueryException;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractStorableUpdateQuery;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -62,8 +63,10 @@ public class OracleUpdateQuery extends AbstractStorableUpdateQuery {
     }
 
     private Map<Schema.Field, Object> createWhereClauseColumnToValueMap() {
-        Map<Schema.Field, Object> bindingMap = getBindings().stream().
-                collect(Collectors.toMap(keyValuePair -> keyValuePair.getKey(), keyValuePair -> keyValuePair.getValue()));
+        Map<Schema.Field, Object> bindingMap = new HashMap<>();
+        for (Pair<Schema.Field, Object> fieldObjectPair : getBindings()) {
+            bindingMap.put(fieldObjectPair.getKey(), fieldObjectPair.getValue());
+        }
         return whereFields.stream().collect(Collectors.toMap(f -> f, f -> bindingMap.get(f)));
     }
 }


### PR DESCRIPTION
Fix ORA-01461 (https://support.oracle.com/knowledge/Middleware/1620109_1.html) when using the "merge" command which is used in addOrUpdate as part of storage layer. We hit this bug when we use addOrUpdate for updating schemaVersionStorable's state after persisting schemaStateStorable. Here we can use update instead of addOrUpdate as it serves the same purpose and help to circumvent the JDBC bug.