### PR TITLE
ISSUE-486 Fix deadlocks in storage layer during concurrent calls to SR

### DIFF
--- a/common/src/main/java/com/hortonworks/registries/common/transaction/TransactionIsolation.java
+++ b/common/src/main/java/com/hortonworks/registries/common/transaction/TransactionIsolation.java
@@ -3,6 +3,11 @@ package com.hortonworks.registries.common.transaction;
 import java.sql.Connection;
 
 public enum TransactionIsolation {
+
+    // Depending upon the target database the transaction isolation is set.
+    // For MYSQL and POSTGRES it is REPEATABLE_READ and
+    // for Oracle it is SERIALIZABLE
+    DATABASE_SENSITIVE(-2),
     // Set default isolation level as recommended by the JDBC driver.
     // When used inside a nested transaction retains current transaction isolation.
     DEFAULT(-1),

--- a/common/src/main/java/com/hortonworks/registries/common/transaction/UnitOfWork.java
+++ b/common/src/main/java/com/hortonworks/registries/common/transaction/UnitOfWork.java
@@ -32,5 +32,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 public @interface UnitOfWork {
     boolean transactional() default true;
-    TransactionIsolation transactionIsolation() default TransactionIsolation.SERIALIZABLE;
+    TransactionIsolation transactionIsolation() default TransactionIsolation.DATABASE_SENSITIVE;
 }

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/DefaultSchemaRegistry.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/DefaultSchemaRegistry.java
@@ -248,7 +248,7 @@ public class DefaultSchemaRegistry implements ISchemaRegistry {
         final Long nextId = storageManager.nextId(givenSchemaMetadataStorable.getNameSpace());
         givenSchemaMetadataStorable.setId(nextId);
         givenSchemaMetadataStorable.setTimestamp(System.currentTimeMillis());
-        storageManager.addOrUpdate(givenSchemaMetadataStorable);
+        storageManager.add(givenSchemaMetadataStorable);
 
         // Add a schema branch for this metadata
         SchemaBranchStorable schemaBranchStorable = new SchemaBranchStorable(SchemaBranch.MASTER_BRANCH, schemaMetadata.getName(), String.format(SchemaBranch.MASTER_BRANCH_DESC, schemaMetadata.getName()), System.currentTimeMillis());
@@ -313,7 +313,7 @@ public class DefaultSchemaRegistry implements ISchemaRegistry {
         SchemaMetadataStorable schemaMetadataStorable = storageManager.get(givenSchemaMetadataStorable.getStorableKey());
         if (schemaMetadataStorable != null) {
             schemaMetadataStorable = SchemaMetadataStorable.updateSchemaMetadata(schemaMetadataStorable, schemaMetadata);
-            storageManager.addOrUpdate(schemaMetadataStorable);
+            storageManager.update(schemaMetadataStorable);
             return schemaMetadataStorable.toSchemaMetadataInfo();
         } else {
             return null;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/DatabaseType.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/DatabaseType.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Hortonworks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.hortonworks.registries.storage.impl.jdbc;
+
+public enum DatabaseType {
+
+    MYSQL("mysql"),
+    POSTGRESQL("postgresql"),
+    ORACLE("oracle");
+
+    private final String value;
+
+    DatabaseType(String dbType) {
+        value = dbType;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    public static DatabaseType fromValue(String otherValue) {
+        for (DatabaseType databaseType : values()) {
+            if (databaseType.value.equals(otherValue))
+                return databaseType;
+        }
+        throw new IllegalArgumentException("Unknown Database Type : " + otherValue);
+    }
+}

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/config/ExecutionConfig.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/config/ExecutionConfig.java
@@ -16,6 +16,7 @@
 
 package com.hortonworks.registries.storage.impl.jdbc.config;
 
+import com.hortonworks.registries.storage.impl.jdbc.DatabaseType;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.QueryExecutor;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
 
@@ -26,14 +27,26 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.Prepa
  * This class should be immutable as the configuration should not change after passed in to the configurable objects
  **/
 public class ExecutionConfig {
+
     private final int queryTimeoutSecs;
+    private final DatabaseType databaseType;
 
     // Replace constructors with Builder pattern as more configuration options become available
+    public ExecutionConfig(int queryTimeoutSecs, DatabaseType databaseType) {
+        this.queryTimeoutSecs = queryTimeoutSecs;
+        this.databaseType = databaseType;
+    }
+
     public ExecutionConfig(int queryTimeoutSecs) {
         this.queryTimeoutSecs = queryTimeoutSecs;
+        this.databaseType = null;
     }
 
     public int getQueryTimeoutSecs() {
         return queryTimeoutSecs;
+    }
+
+    public DatabaseType getDatabaseType() {
+        return databaseType;
     }
 }

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/QueryExecutorFactory.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/QueryExecutorFactory.java
@@ -17,6 +17,7 @@
 package com.hortonworks.registries.storage.impl.jdbc.provider;
 
 import com.google.common.collect.Lists;
+import com.hortonworks.registries.storage.impl.jdbc.DatabaseType;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
 import com.hortonworks.registries.storage.impl.jdbc.connection.HikariCPConnectionBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.factory.MySqlExecutor;
@@ -42,7 +43,7 @@ public class QueryExecutorFactory {
     public static QueryExecutor get(String type, Map<String, Object> dbProperties) {
 
         HikariCPConnectionBuilder connectionBuilder = getHikariCPConnnectionBuilder(dbProperties);
-        ExecutionConfig executionConfig = getExecutionConfig(dbProperties);
+        ExecutionConfig executionConfig = getExecutionConfig(type, dbProperties);
 
         QueryExecutor queryExecutor = null;
         switch (type) {
@@ -78,7 +79,7 @@ public class QueryExecutorFactory {
         return new HikariCPConnectionBuilder(hikariConfig);
     }
 
-    private static ExecutionConfig getExecutionConfig(Map<String, Object> dbProperties) {
+    private static ExecutionConfig getExecutionConfig(String type, Map<String, Object> dbProperties) {
         int queryTimeOutInSecs = -1;
         if (dbProperties.containsKey("queryTimeoutInSecs")) {
             queryTimeOutInSecs = (Integer) dbProperties.get("queryTimeoutInSecs");
@@ -87,6 +88,6 @@ public class QueryExecutorFactory {
             }
         }
 
-        return new ExecutionConfig(queryTimeOutInSecs);
+        return new ExecutionConfig(queryTimeOutInSecs, DatabaseType.fromValue(type));
     }
 }

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/factory/MySqlExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/mysql/factory/MySqlExecutor.java
@@ -17,13 +17,11 @@
 package com.hortonworks.registries.storage.impl.jdbc.provider.mysql.factory;
 
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Lists;
 import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
 import com.hortonworks.registries.storage.impl.jdbc.connection.ConnectionBuilder;
-import com.hortonworks.registries.storage.impl.jdbc.connection.HikariCPConnectionBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlInsertQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlInsertUpdateDuplicate;
 import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MySqlSelectQuery;
@@ -31,14 +29,10 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.mysql.query.MysqlUp
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.AbstractQueryExecutor;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
-import com.hortonworks.registries.storage.impl.jdbc.util.Util;
 import com.hortonworks.registries.storage.search.SearchQuery;
-import com.zaxxer.hikari.HikariConfig;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 
 /**
  * SQL query executor for MySQL DB.

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleSequenceIdQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/query/OracleSequenceIdQuery.java
@@ -17,11 +17,9 @@
 package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.query;
 
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
-import com.hortonworks.registries.storage.impl.jdbc.connection.ConnectionBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.statement.OracleDataTypeContext;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.AbstractSqlQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
-import com.hortonworks.registries.storage.transaction.TransactionBookKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/TransactionEventListener.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/TransactionEventListener.java
@@ -75,7 +75,11 @@ public class TransactionEventListener implements ApplicationEventListener {
         @Override
         public void onEvent(RequestEvent event) {
             final RequestEvent.Type eventType = event.getType();
+
             if (eventType == RequestEvent.Type.RESOURCE_METHOD_START) {
+
+                // Start transaction before invoking the resource method for the request
+
                 Optional<UnitOfWork> unitOfWork = methodMap.computeIfAbsent(event.getUriInfo()
                                                                                  .getMatchedResourceMethod(),
                                                                             UnitOfWorkEventListener::registerUnitOfWorkAnnotations);
@@ -90,18 +94,29 @@ public class TransactionEventListener implements ApplicationEventListener {
                     isTransactionActive = true;
                 }
             } else if (eventType == RequestEvent.Type.RESP_FILTERS_START) {
-                // not supporting transactions to filters
-            } else if (eventType == RequestEvent.Type.ON_EXCEPTION) {
+
+                // Once the response from the resource method is available we should either rollback or commit the
+                // transaction. In case the resource method throws an error, ON_EXCEPTION is called first which will
+                // rollback the transaction and eventually RESP_FILTERS_START is called (which won't do anything)
+                // after exception mapper handles the exception. In case the exception is not thrown, RESP_FILTERS_START
+                // is called which then commits the transaction.
+                //      Its not advisable to handle rollbacks and commits when the request transitions to FINISHED state.
+                // For example, we might have a client which add an entity (E1) and lets say entity id is returned as a response.
+                // Lets say the client then adds a second entity (E2) which has foreign key reference to the first entity (E1).
+                // If we commit the transaction in FINISHED state, then the client received the entity id after adding E1
+                // at time say t1 and adding entity E2 at t2, then we might run into a scenario where we might commit the changes
+                // to E1 only after t2 as responses to the client are dispatched before FINISHED, then client will receive
+                // an error that E1 is not found even thought the operation of adding E1 had succeeded from the client's point of view.
+
                 if (useTransactionForUnitOfWork && isTransactionActive) {
-                    transactionManager.rollbackTransaction();
-                    isTransactionActive = false;
-                }
-            } else if (eventType == RequestEvent.Type.FINISHED) {
-                if (useTransactionForUnitOfWork && event.isSuccess()) {
                     transactionManager.commitTransaction();
                     isTransactionActive = false;
                 }
-                else if (useTransactionForUnitOfWork && !event.isSuccess() && isTransactionActive) {
+            } else if (eventType == RequestEvent.Type.ON_EXCEPTION) {
+
+                // Rollback the transaction in case an exception is thrown from the resource method.
+
+                if (useTransactionForUnitOfWork && isTransactionActive) {
                     transactionManager.rollbackTransaction();
                     isTransactionActive = false;
                 }


### PR DESCRIPTION
In case of code path for adding schema metadata, we first do a get(schemaMetadataName), if the get returns a null then we add the new schemaMetadata else we return the schemaMetadataId from the get() call. The current transaction isolation level in SR is SERIALIZABLE, in this case, the get() call gets a shared lock and the add() call get an exclusive lock within a transaction. If two threads are invoking this API we might run into a situation where thread1 has obtained a shared lock and thread2 has also obtained the shared lock but thread1 can't get an exclusive lock because of a shared lock held by thread2 and thread2 can't get an exclusive lock because of a shared lock held by thread1. So, we run into a deadlock. The solution here would be to reduce the transaction isolation level to REPETABLE_READS for MySQL and POSTGRES and since ORACLE doesn't use this locking mechanism to in case of SERIALIZABLE, we can retain the current transaction isolation level for ORACLE.

Author: Sarvanan Raju <sraju@hortonworks.com>

Reviewers: @satishd,@priyank5485,@raju-saravanan

Closes #484 from raju-saravanan/deadlock