### PR TITLE
Fix SampleApplicationTest

### DIFF
--- a/examples/schema-registry/pom.xml
+++ b/examples/schema-registry/pom.xml
@@ -18,4 +18,15 @@
         <module>schema-lifecycle</module>
     </modules>
 
+    <properties>
+        <commons-codec.version>1.11</commons-codec.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
Fixing the test by adding a missing dependency.

It was failing before with following stack trace:

com.google.common.util.concurrent.UncheckedExecutionException: java.lang.RuntimeException: An exception with message [org/apache/commons/codec/binary/Hex] was thrown while processing request. 	at com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient.handleSchemaIdVersionResponse(SchemaRegistryClient.java:591) 	at com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient.doAddSchemaVersion(SchemaRegistryClient.java:577) 	at com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient.lambda$addSchemaVersion$1(SchemaRegistryClient.java:515) 	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4870) 	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3524) 	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2273) 	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2156) 	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2046) 	at com.google.common.cache.LocalCache.get(LocalCache.java:3943) 	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4865) 	at com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient.addSchemaVersion(SchemaRegistryClient.java:514) 	at com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient.addSchemaVersion(SchemaRegistryClient.java:450) 	at com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient.addSchemaVersion(SchemaRegistryClient.java:431) 	at com.hortonworks.registries.schemaregistry.examples.avro.SampleSchemaRegistryClientApp.runSchemaApis(SampleSchemaRegistryClientApp.java:74) 	at com.hortonworks.registries.schemaregistry.examples.avro.SampleApplicationTest.testApis(SampleApplicationTest.java:42)
--


