### PR TITLE
ISSUE-513: Fix storage manager to correctly handle the types in queries

### DIFF
--- a/common/src/main/java/com/hortonworks/registries/common/Schema.java
+++ b/common/src/main/java/com/hortonworks/registries/common/Schema.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,16 @@ public class Schema implements Serializable {
 
         private final Class<?> javaType;
 
+        private static final Map<Class<?>, Type> classToTypes = buildClassToTypes();
+
+        private static Map<Class<?>, Type> buildClassToTypes() {
+            Map<Class<?>, Type> res = new HashMap<>();
+            for (Type type: values()) {
+                res.put(type.getJavaType(), type);
+            }
+            return res;
+        }
+
         Type(Class<?> javaType) {
             this.javaType = javaType;
         }
@@ -79,11 +90,9 @@ public class Schema implements Serializable {
         public static Type getTypeOfVal(String val) {
             Type type = null;
             Type[] types = Type.values();
-
             if (val != null && (val.equalsIgnoreCase("true") || val.equalsIgnoreCase("false"))) {
                 type = BOOLEAN;
             }
-
             for (int i = 1; type == null && i < STRING.ordinal(); i++) {
                 final Class clazz = types[i].getJavaType();
                 try {
@@ -97,12 +106,14 @@ public class Schema implements Serializable {
                     /* Exception is thrown if type does not match. Ignore to search next type */
                 }
             }
-
             if (type == null) {
                 type = STRING;
             }
-
             return type;
+        }
+
+        public static Type fromJavaType(Class<?> javaType) {
+            return classToTypes.getOrDefault(javaType, STRING);
         }
     }
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/factory/OracleExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/factory/OracleExecutor.java
@@ -34,7 +34,7 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.oracle.statement.Or
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory.AbstractQueryExecutor;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlQuery;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
-import com.hortonworks.registries.storage.impl.jdbc.util.CaseAgnosticStringSet;
+import com.hortonworks.registries.storage.impl.jdbc.util.Columns;
 import com.hortonworks.registries.storage.search.SearchQuery;
 
 import java.sql.Connection;
@@ -123,15 +123,16 @@ public class OracleExecutor extends AbstractQueryExecutor {
     }
 
     @Override
-    public CaseAgnosticStringSet getColumnNames(String namespace) throws SQLException {
-        CaseAgnosticStringSet columns = new CaseAgnosticStringSet();
+    public Columns getColumns(String namespace) throws SQLException {
+        Columns columns = new Columns();
         Connection connection = null;
         try {
             connection = getConnection();
             final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), ORACLE_DATA_TYPE_CONTEXT,
                     new OracleSelectQuery(namespace)).getMetaData();
             for (int i = 1; i <= rsMetadata.getColumnCount(); i++) {
-                columns.add(rsMetadata.getColumnName(i));
+                columns.add(rsMetadata.getColumnName(i),
+                        getType(rsMetadata.getColumnType(i), rsMetadata.getPrecision(i)));
             }
             return columns;
         } catch (SQLException e) {

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/AbstractQueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/AbstractQueryExecutor.java
@@ -20,6 +20,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
+import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.common.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableFactory;
@@ -34,7 +35,8 @@ import com.hortonworks.registries.storage.impl.jdbc.provider.sql.query.SqlSelect
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.DefaultStorageDataTypeContext;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.PreparedStatementBuilder;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.StorageDataTypeContext;
-import com.hortonworks.registries.storage.impl.jdbc.util.CaseAgnosticStringSet;
+import com.hortonworks.registries.storage.impl.jdbc.util.Columns;
+import com.hortonworks.registries.storage.impl.jdbc.util.Util;
 import com.hortonworks.registries.storage.transaction.TransactionBookKeeper;
 import com.hortonworks.registries.storage.transaction.TransactionState;
 
@@ -126,15 +128,16 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
     }
 
     @Override
-    public CaseAgnosticStringSet getColumnNames(String namespace) throws SQLException {
-        CaseAgnosticStringSet columns = new CaseAgnosticStringSet();
+    public Columns getColumns(String namespace) throws SQLException {
+        Columns columns = new Columns();
         Connection connection = null;
         try {
             connection = getConnection();
             final ResultSetMetaData rsMetadata = PreparedStatementBuilder.of(connection, new ExecutionConfig(queryTimeoutSecs), storageDataTypeContext,
                                                                              new SqlSelectQuery(namespace)).getMetaData();
             for (int i = 1; i <= rsMetadata.getColumnCount(); i++) {
-                columns.add(rsMetadata.getColumnName(i));
+                columns.add(rsMetadata.getColumnName(i),
+                        getType(rsMetadata.getColumnType(i), rsMetadata.getPrecision(i)));
             }
             return columns;
         } catch (SQLException e) {
@@ -145,6 +148,10 @@ public abstract class AbstractQueryExecutor implements QueryExecutor {
                 closeConnection(connection);
             }
         }
+    }
+
+    protected Schema.Type getType(int sqlType, int precision) {
+        return Schema.Type.fromJavaType(Util.getJavaType(sqlType, precision));
     }
 
     public void closeConnection(Connection connection) {

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
@@ -22,9 +22,8 @@ import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableFactory;
 import com.hortonworks.registries.storage.StorableKey;
 import com.hortonworks.registries.storage.exception.NonIncrementalColumnException;
-import com.hortonworks.registries.storage.exception.StorageException;
 import com.hortonworks.registries.storage.impl.jdbc.config.ExecutionConfig;
-import com.hortonworks.registries.storage.impl.jdbc.util.CaseAgnosticStringSet;
+import com.hortonworks.registries.storage.impl.jdbc.util.Columns;
 import com.hortonworks.registries.storage.search.SearchQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,9 +117,9 @@ public interface QueryExecutor {
     <T extends Storable> Collection<T> select(SearchQuery searchQuery);
 
     /**
-     *  @return returns set of column names for a given table
+     *  @return returns set of columns for a given table
      */
-    CaseAgnosticStringSet getColumnNames(String namespace) throws SQLException;
+    Columns getColumns(String namespace) throws SQLException;
 
     /**
      *  Begins the transaction

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/util/Columns.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/util/Columns.java
@@ -16,19 +16,22 @@
 
 package com.hortonworks.registries.storage.impl.jdbc.util;
 
-import java.util.HashSet;
+import com.hortonworks.registries.common.Schema;
 
-public class CaseAgnosticStringSet extends HashSet<String> {
+import java.util.HashMap;
 
-    public boolean add(String e) {
-        return super.add(e.toLowerCase());
-    }
+public class Columns {
+  private HashMap<String, Schema.Type> colums = new HashMap<>();
 
-    public boolean contains(String o) {
-        return super.contains(o.toLowerCase());
-    }
+  public Schema.Type add(String name, Schema.Type type) {
+    return colums.put(name.toLowerCase(), type);
+  }
 
-    public boolean remove(String o) {
-        return super.remove(o.toLowerCase());
-    }
+  public Schema.Type getType(String name) {
+    return colums.get(name.toLowerCase());
+  }
+
+  public Schema.Type remove(String name) {
+    return colums.remove(name.toLowerCase());
+  }
 }


### PR DESCRIPTION
Currently the JDBC storage manager user the value of the query parameter to guess the column type and uses this to construct the prepared statement. This is fragile and breaks when the value appears to be of a different type. For example a varchar column name and query string name="123".

We can leverage the JDBC result set to figure out the sql type and map it to the Schema.Type to fix this.