### PR TITLE
ISSUE-538 Move transaction package from common to storage-core

### DIFF
--- a/schema-registry/rest-service/src/main/java/com/hortonworks/registries/schemaregistry/webservice/ConfluentSchemaRegistryCompatibleResource.java
+++ b/schema-registry/rest-service/src/main/java/com/hortonworks/registries/schemaregistry/webservice/ConfluentSchemaRegistryCompatibleResource.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hortonworks.registries.common.catalog.CatalogResponse;
 import com.hortonworks.registries.common.ha.LeadershipParticipant;
-import com.hortonworks.registries.common.transaction.UnitOfWork;
+import com.hortonworks.registries.storage.transaction.UnitOfWork;
 import com.hortonworks.registries.common.util.WSUtils;
 import com.hortonworks.registries.schemaregistry.ISchemaRegistry;
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;

--- a/schema-registry/rest-service/src/main/java/com/hortonworks/registries/schemaregistry/webservice/SchemaRegistryResource.java
+++ b/schema-registry/rest-service/src/main/java/com/hortonworks/registries/schemaregistry/webservice/SchemaRegistryResource.java
@@ -19,7 +19,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.hortonworks.registries.common.SchemaRegistryVersion;
 import com.hortonworks.registries.common.catalog.CatalogResponse;
 import com.hortonworks.registries.common.ha.LeadershipParticipant;
-import com.hortonworks.registries.common.transaction.UnitOfWork;
+import com.hortonworks.registries.storage.transaction.UnitOfWork;
 import com.hortonworks.registries.common.util.WSUtils;
 import com.hortonworks.registries.schemaregistry.AggregatedSchemaMetadataInfo;
 import com.hortonworks.registries.schemaregistry.CompatibilityResult;

--- a/storage/core/pom.xml
+++ b/storage/core/pom.xml
@@ -15,11 +15,6 @@
         <!-- module dependency -->
         <dependency>
             <groupId>com.hortonworks.registries</groupId>
-            <artifactId>registry-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hortonworks.registries</groupId>
             <artifactId>cache</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/NOOPTransactionManager.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/NOOPTransactionManager.java
@@ -16,7 +16,7 @@
 
 package com.hortonworks.registries.storage;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.exception.StorageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/TransactionManager.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/TransactionManager.java
@@ -16,7 +16,7 @@
 
 package com.hortonworks.registries.storage;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import java.util.concurrent.TimeUnit;
 
 public interface TransactionManager {

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/JdbcStorageManager.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/JdbcStorageManager.java
@@ -18,7 +18,7 @@ package com.hortonworks.registries.storage.impl.jdbc;
 
 import com.hortonworks.registries.common.QueryParam;
 import com.hortonworks.registries.common.Schema;
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.PrimaryKey;
 import com.hortonworks.registries.storage.Storable;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/factory/PostgresqlExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/postgresql/factory/PostgresqlExecutor.java
@@ -21,7 +21,7 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.postgresql.factory
 
 import com.google.common.cache.CacheBuilder;
 import com.hortonworks.registries.common.Schema;
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableKey;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/AbstractQueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/AbstractQueryExecutor.java
@@ -21,7 +21,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.hortonworks.registries.common.Schema;
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableFactory;
 import com.hortonworks.registries.storage.StorableKey;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/factory/QueryExecutor.java
@@ -16,7 +16,7 @@
 
 package com.hortonworks.registries.storage.impl.jdbc.provider.sql.factory;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.OrderByField;
 import com.hortonworks.registries.storage.Storable;
 import com.hortonworks.registries.storage.StorableFactory;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/ManagedTransaction.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/ManagedTransaction.java
@@ -16,7 +16,6 @@
 
 package com.hortonworks.registries.storage.transaction;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.transaction.functional.ManagedTransactionConsumer;
 import com.hortonworks.registries.storage.transaction.functional.ManagedTransactionFunction;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/TransactionEventListener.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/TransactionEventListener.java
@@ -16,8 +16,6 @@
 
 package com.hortonworks.registries.storage.transaction;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
-import com.hortonworks.registries.common.transaction.UnitOfWork;
 import com.hortonworks.registries.storage.TransactionManager;
 import org.glassfish.jersey.server.model.ResourceMethod;
 import org.glassfish.jersey.server.monitoring.ApplicationEvent;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/TransactionIsolation.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/TransactionIsolation.java
@@ -1,4 +1,4 @@
-package com.hortonworks.registries.common.transaction;
+package com.hortonworks.registries.storage.transaction;
 
 import java.sql.Connection;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/UnitOfWork.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/transaction/UnitOfWork.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package com.hortonworks.registries.common.transaction;
+package com.hortonworks.registries.storage.transaction;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/storage/core/src/test/java/com/hortonworks/registries/storage/filestorage/DbFileStorageTest.java
+++ b/storage/core/src/test/java/com/hortonworks/registries/storage/filestorage/DbFileStorageTest.java
@@ -15,7 +15,7 @@
  **/
 package com.hortonworks.registries.storage.filestorage;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.StorageManager;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.exception.StorageException;

--- a/storage/core/src/test/java/com/hortonworks/registries/storage/filestorage/TransactionTest.java
+++ b/storage/core/src/test/java/com/hortonworks/registries/storage/filestorage/TransactionTest.java
@@ -16,7 +16,7 @@
 
 package com.hortonworks.registries.storage.filestorage;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.StorageManager;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.impl.jdbc.JdbcStorageManager;

--- a/storage/core/src/test/java/com/hortonworks/registries/storage/transaction/ManagedTransactionTest.java
+++ b/storage/core/src/test/java/com/hortonworks/registries/storage/transaction/ManagedTransactionTest.java
@@ -1,6 +1,5 @@
 package com.hortonworks.registries.storage.transaction;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
 import com.hortonworks.registries.storage.TransactionManager;
 import com.hortonworks.registries.storage.exception.IgnoreTransactionRollbackException;
 import mockit.Expectations;

--- a/tag-registry/src/main/java/com/hortonworks/registries/tag/service/TagCatalogResource.java
+++ b/tag-registry/src/main/java/com/hortonworks/registries/tag/service/TagCatalogResource.java
@@ -18,7 +18,7 @@ package com.hortonworks.registries.tag.service;
 import com.codahale.metrics.annotation.Timed;
 import com.hortonworks.registries.common.QueryParam;
 import com.hortonworks.registries.common.exception.service.exception.request.EntityNotFoundException;
-import com.hortonworks.registries.common.transaction.UnitOfWork;
+import com.hortonworks.registries.storage.transaction.UnitOfWork;
 import com.hortonworks.registries.common.util.WSUtils;
 import com.hortonworks.registries.tag.Tag;
 import com.hortonworks.registries.tag.TaggedEntity;

--- a/webservice/src/main/java/com/hortonworks/registries/cron/RefreshHAServerListTask.java
+++ b/webservice/src/main/java/com/hortonworks/registries/cron/RefreshHAServerListTask.java
@@ -16,7 +16,7 @@
 
 package com.hortonworks.registries.cron;
 
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.schemaregistry.HAServerNotificationManager;
 import com.hortonworks.registries.schemaregistry.HostConfigStorable;
 import com.hortonworks.registries.storage.StorageManager;

--- a/webservice/src/main/java/com/hortonworks/registries/webservice/RegistryApplication.java
+++ b/webservice/src/main/java/com/hortonworks/registries/webservice/RegistryApplication.java
@@ -17,7 +17,7 @@ package com.hortonworks.registries.webservice;
 
 import com.hortonworks.registries.common.GenericExceptionMapper;
 import com.hortonworks.registries.common.ServletFilterConfiguration;
-import com.hortonworks.registries.common.transaction.TransactionIsolation;
+import com.hortonworks.registries.storage.transaction.TransactionIsolation;
 import com.hortonworks.registries.cron.RefreshHAServerManagedTask;
 import com.hortonworks.registries.schemaregistry.HAServerNotificationManager;
 import com.hortonworks.registries.schemaregistry.HAServersAware;
@@ -39,7 +39,6 @@ import com.hortonworks.registries.storage.StorageManager;
 import com.hortonworks.registries.storage.StorageManagerAware;
 import com.hortonworks.registries.storage.StorageProviderConfiguration;
 import io.dropwizard.Application;
-import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;


### PR DESCRIPTION
This helps us to isolate `storage-core` with `registry-common`, which brings huge number of transitive dependencies especially from `hadoop-client`.

Closes #538