### PR TITLE
ISSUE-540 Exclude Avro dependency from registry-common module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -73,6 +73,10 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-webapp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This would save lots of modules which has `registry-common` as a transitive dependency.

Closes #540 