### PR TITLE
MINOR: Upgrade jackson-databind to v2.9.8 to fix the below CVEs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.12</junit.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <commons-cli.version>1.3.1</commons-cli.version>
         <commons.version>2.5</commons.version>
         <slf4j.version>1.7.25</slf4j.version>

--- a/schema-registry/serdes/pom.xml
+++ b/schema-registry/serdes/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.7.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
CVE-2018-14719
CVE-2018-14720
CVE-2018-14721
CVE-2018-1000873
CVE-2018-7489
CVE-2018-19362
CVE-2017-15095
CVE-2018-19361
CVE-2017-7525
CVE-2018-19360
CVE-2017-17485
CVE-2018-5968