### PR TITLE
ISSUE-548: Make compatible with Avro 1.9.0

### DIFF
--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaBranchKey.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaBranchKey.java
@@ -16,10 +16,10 @@
 
 package com.hortonworks.registries.schemaregistry;
 
-import avro.shaded.com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class contains schema branch name and schema metadata name.
@@ -44,8 +44,8 @@ public final class SchemaBranchKey implements Serializable {
      * @param schemaMetadataName    schema metadata name from which the schema branch was created
      */
     public SchemaBranchKey(String schemaBranchName, String schemaMetadataName) {
-        Preconditions.checkNotNull(schemaBranchName, "schemaBranchName can not be null");
-        Preconditions.checkNotNull(schemaMetadataName, "schemaMetadataName can not be null");
+        Objects.requireNonNull(schemaBranchName, "schemaBranchName can not be null");
+        Objects.requireNonNull(schemaMetadataName, "schemaMetadataName can not be null");
         this.schemaBranchName = schemaBranchName;
         this.schemaMetadataName = schemaMetadataName;
     }

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProvider.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProvider.java
@@ -23,7 +23,6 @@ import com.hortonworks.registries.schemaregistry.SchemaFieldInfo;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
 import org.apache.avro.Schema;
-import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,7 +181,7 @@ public class AvroSchemaProvider extends AbstractSchemaProvider {
                     appendable.append("{\"name\":\"").append(field.name()).append("\"").append(",\"type\":");
 
                     // handle default value
-                    JsonNode defaultValue = field.defaultValue();
+                    Object defaultValue = field.defaultVal();
                     if (defaultValue != null) {
                         appendable.append(defaultValue.toString());
                     }

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaResolver.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaResolver.java
@@ -23,8 +23,8 @@ import com.hortonworks.registries.schemaregistry.SchemaVersionRetriever;
 import com.hortonworks.registries.schemaregistry.errors.CyclicSchemaDependencyException;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
-import org.codehaus.jackson.node.NullNode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -171,7 +171,7 @@ public class AvroSchemaResolver implements SchemaResolver {
                 Schema.Field rebuiltField = new Schema.Field(field.name(),
                                                    fieldSchema,
                                                    field.doc(),
-                                                   currentFieldTypeIsUnion ? NullNode.getInstance() : field.defaultValue(),
+                                                   currentFieldTypeIsUnion ? JsonProperties.NULL_VALUE : field.defaultVal(),
                                                    field.order());
                 for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
                     rebuiltField.addProp(prop.getKey(), prop.getValue());
@@ -185,44 +185,13 @@ public class AvroSchemaResolver implements SchemaResolver {
                 for (String alias : schema.getAliases()) {
                     updatedRootSchema.addAlias(alias);
                 }
-                for (Map.Entry<String, org.codehaus.jackson.JsonNode> nodeEntry : schema.getJsonProps().entrySet()) {
-                    updatedRootSchema.addProp(nodeEntry.getKey(), nodeEntry.getValue());
+                for (Map.Entry<String, Object> prop : schema.getObjectProps().entrySet()) {
+                    updatedRootSchema.addProp(prop.getKey(), prop.getValue());
                 }
             }
         }
 
         return updatedRootSchema;
-    }
-
-    private Schema updateUnionFields(Schema schema) {
-        Schema updatedSchema = schema;
-        List<Schema.Field> fields = schema.getFields();
-        boolean hasUnionType = false;
-        List<Schema.Field> updatedFields = new ArrayList<>(fields.size());
-        for (Schema.Field field : fields) {
-            Schema fieldSchema = field.schema();
-            Schema.Field updatedField = field;
-            // if it is union and first type is null then set default value as null
-            if (fieldSchema.getType() == Schema.Type.UNION &&
-                    fieldSchema.getTypes().get(0).getType() == Schema.Type.NULL) {
-                updatedField = new Schema.Field(field.name(), fieldSchema, field.doc(), NullNode.getInstance(), field.order());
-                hasUnionType = true;
-            }
-            updatedFields.add(updatedField);
-        }
-
-        if (hasUnionType) {
-            updatedSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError());
-            updatedSchema.setFields(updatedFields);
-            for (String alias : schema.getAliases()) {
-                updatedSchema.addAlias(alias);
-            }
-            for (Map.Entry<String, org.codehaus.jackson.JsonNode> nodeEntry : schema.getJsonProps().entrySet()) {
-                updatedSchema.addProp(nodeEntry.getKey(), nodeEntry.getValue());
-            }
-        }
-
-        return updatedSchema;
     }
 
     private Map<String, Schema> traverseIncludedSchemaTypes(String schemaText,

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaValidator.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaValidator.java
@@ -504,7 +504,7 @@ public final class AvroSchemaValidator implements SchemaValidator<Schema> {
                 if (writerField == null) {
                     // Reader field does not correspond to any field in the writer
                     // record schema, so the reader field must have a default value.
-                    if (readerField.defaultValue() == null) {
+                    if (readerField.defaultVal() == null) {
                         if (!isUnionWithFirstTypeAsNull(readerFieldSchema)) {
                             // reader field has no default value
                             String message = String.format("Reader schema missing default value for field: %s", readerField

--- a/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaBranchStorable.java
+++ b/schema-registry/core/src/main/java/com/hortonworks/registries/schemaregistry/SchemaBranchStorable.java
@@ -16,10 +16,10 @@
 
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.storage.PrimaryKey;
 import com.hortonworks.registries.storage.catalog.AbstractStorable;
-import org.codehaus.jackson.annotate.JsonIgnore;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
Preparing for the upcoming release of Avro 1.9.0,
there are some methods and transitive dependencies
that have been removed.
Resolves #548 

~~This still needs some work regarding default values.
As of 1.8.x, Avro's Schema.Field class exposed
'defaultValue', returning a JsonNode. That method is
package private in 1.9.0-SNAPSHOT, in favor of defaultVal
returning an Object. In this instance, we have no way to
distinguish between 'null' as a default and a field having
no default at all.
So we need to figure out how to manage
these cases. We could try to squeeze in 'hasDefault' before
the new Avro release but we will be binary incompatible at
that point so we would need 2 registry builds for Avro 1.8.x
and 1.9.0.~~

Mostly false alarm on the above comment. I spent a bunch of time
setting up reflective junk to mitigate what I thought was
a problem but it turned out that `defaultVal()` returns
`JsonProperties.NULL_VALUE` when a field has a default
of 'null'. So looks like we are mostly good.
The only failure against Avro 1.9.0-SNAPSHOT came when using the
Confluent schema registry in the schema-registry-webservice
tests.