### PR TITLE
Download Kafka from a different server

### DIFF
--- a/docker/images/kafka/Dockerfile
+++ b/docker/images/kafka/Dockerfile
@@ -20,7 +20,7 @@ ENV KAFKA_VERSION=$kafka_version \
     SCALA_VERSION=$scala_version
 
 ARG FILE_NAME=kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
-ADD http://redrockdigimark.com/apachemirror/kafka/${KAFKA_VERSION}/${FILE_NAME} /opt/
+ADD https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${FILE_NAME} /opt/
 
 RUN tar -xf /opt/${FILE_NAME} -C /opt/ \
     && ln -sf /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka \


### PR DESCRIPTION
It appears http://redrockdigimark.com/apachemirror/kafka is no longer operational, and thus `docker build` for `apache-kafka:1.0.0` produces the following error message:

```
Step 6/12 : ADD http://redrockdigimark.com/apachemirror/kafka/${KAFKA_VERSION}/${FILE_NAME} /opt/
ADD failed: failed to GET http://redrockdigimark.com/apachemirror/kafka/1.0.0/kafka_2.12-1.0.0.tgz with status 500 Internal Server Error: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at
 info@redrockdigimark.com to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.29 (Ubuntu) Server at redrockdigimark.com Port 443</address>
</body></html>
```

This PR alters the download URL so that it fetches the file from the official mirror site. Switching from plain HTTP to secure HTTPS would be a nice addition ;-)