### PR TITLE
ISSUE-631 : Schema Registry numeric properties cannot be set via a property file

### DIFF
--- a/examples/schema-registry/avro/src/main/java/com/hortonworks/registries/schemaregistry/examples/avro/SampleSchemaRegistryClientApp.java
+++ b/examples/schema-registry/avro/src/main/java/com/hortonworks/registries/schemaregistry/examples/avro/SampleSchemaRegistryClientApp.java
@@ -251,10 +251,10 @@ public class SampleSchemaRegistryClientApp {
     public static Map<String, Object> createConfig(String schemaRegistryUrl) {
         Map<String, Object> config = new HashMap<>();
         config.put(SchemaRegistryClient.Configuration.SCHEMA_REGISTRY_URL.name(), schemaRegistryUrl);
-        config.put(SchemaRegistryClient.Configuration.CLASSLOADER_CACHE_SIZE.name(), 10L);
-        config.put(SchemaRegistryClient.Configuration.CLASSLOADER_CACHE_EXPIRY_INTERVAL_SECS.name(), 5000L);
-        config.put(SchemaRegistryClient.Configuration.SCHEMA_VERSION_CACHE_SIZE.name(), 1000L);
-        config.put(SchemaRegistryClient.Configuration.SCHEMA_VERSION_CACHE_EXPIRY_INTERVAL_SECS.name(), 60 * 60 * 1000L);
+        config.put(SchemaRegistryClient.Configuration.CLASSLOADER_CACHE_SIZE.name(), 10);
+        config.put(SchemaRegistryClient.Configuration.CLASSLOADER_CACHE_EXPIRY_INTERVAL_SECS.name(), 5000);
+        config.put(SchemaRegistryClient.Configuration.SCHEMA_VERSION_CACHE_SIZE.name(), 1000);
+        config.put(SchemaRegistryClient.Configuration.SCHEMA_VERSION_CACHE_EXPIRY_INTERVAL_SECS.name(), 60 * 60 * 1000);
         return config;
     }
 

--- a/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/client/SchemaRegistryClient.java
+++ b/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/client/SchemaRegistryClient.java
@@ -1253,6 +1253,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                       String.class,
                                       "URL of schema registry to which this client connects to. For ex: http://localhost:9090/api/v1",
                                       "http://localhost:9090/api/v1",
+                                      ConfigEntry.StringConverter.get(),
                                       ConfigEntry.NonEmptyStringValidator.get());
 
         /**
@@ -1268,6 +1269,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      String.class,
                                      "URL of schema registry to which this client connects to. For ex: http://localhost:9090/api/v1",
                                      DEFAULT_LOCAL_JARS_PATH,
+                                     ConfigEntry.StringConverter.get(),
                                      ConfigEntry.NonEmptyStringValidator.get());
 
         /**
@@ -1289,6 +1291,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Maximum size of classloader cache",
                                      DEFAULT_CLASSLOADER_CACHE_SIZE,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1300,6 +1303,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Expiry interval(in seconds) of an entry in classloader cache",
                                      DEFAULT_CLASSLOADER_CACHE_EXPIRY_INTERVAL_SECS,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         public static final long DEFAULT_SCHEMA_CACHE_SIZE = 1024;
@@ -1313,6 +1317,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Maximum size of schema version cache",
                                      DEFAULT_SCHEMA_CACHE_SIZE,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1323,6 +1328,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Expiry interval(in seconds) of an entry in schema version cache",
                                      DEFAULT_SCHEMA_CACHE_EXPIRY_INTERVAL_SECS,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1333,6 +1339,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Maximum size of schema metadata cache",
                                      DEFAULT_SCHEMA_CACHE_SIZE,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1343,6 +1350,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Expiry interval(in seconds) of an entry in schema metadata cache",
                                      DEFAULT_SCHEMA_CACHE_EXPIRY_INTERVAL_SECS,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1354,6 +1362,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Maximum size of schema text cache",
                                      DEFAULT_SCHEMA_CACHE_SIZE,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1364,6 +1373,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      Integer.class,
                                      "Expiry interval(in seconds) of an entry in schema text cache.",
                                      DEFAULT_SCHEMA_CACHE_EXPIRY_INTERVAL_SECS,
+                                     ConfigEntry.IntegerConverter.get(),
                                      ConfigEntry.PositiveNumberValidator.get());
 
         /**
@@ -1374,6 +1384,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                                      String.class,
                                      "Schema Registry URL selector class.",
                                      FailoverUrlSelector.class.getName(),
+                                     ConfigEntry.StringConverter.get(),
                                      ConfigEntry.NonEmptyStringValidator.get());
 
         /**
@@ -1384,6 +1395,7 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
                         String.class,
                         "Schema Registry Dynamic JAAS config for SASL connection.",
                         null,
+                        ConfigEntry.StringConverter.get(),
                         ConfigEntry.NonEmptyStringValidator.get());
 
         // connection properties
@@ -1411,16 +1423,18 @@ public class SchemaRegistryClient implements ISchemaRegistryClient {
             for (Map.Entry<String, ?> entry : config.entrySet()) {
                 String key = entry.getKey();
                 Object value = entry.getValue();
+                Object finalValue = value;
 
                 ConfigEntry configEntry = options.get(key);
                 if (configEntry != null) {
                     if (value != null) {
-                        configEntry.validator().validate((value));
+                        finalValue = configEntry.converter().convert(value);
+                        configEntry.validator().validate((finalValue));
                     } else {
-                        value = configEntry.defaultValue();
+                        finalValue = configEntry.defaultValue();
                     }
                 }
-                result.put(key, value);
+                result.put(key, finalValue);
             }
 
             return result;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/ConfigEntry.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/ConfigEntry.java
@@ -14,6 +14,8 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.hortonworks.registries.schemaregistry.errors.ConfigTypeConversionException;
+
 import java.io.Serializable;
 import java.util.Collections;
 
@@ -153,9 +155,15 @@ public final class ConfigEntry<T> implements Serializable {
         @Override
         public Integer convert(Object obj) {
             if (obj instanceof String) {
-                return Integer.valueOf((String)obj);
-            } else {
+                try {
+                    return Integer.valueOf((String)obj);
+                } catch (NumberFormatException e) {
+                    throw new ConfigTypeConversionException(String.format("Value: %s can't be parsed as an Integer", obj), e);
+                }
+            } else if (obj instanceof Integer){
                 return ((Integer) obj);
+            } else {
+                throw new ConfigTypeConversionException(String.format("Value: %s (type: %s) is expected to be convertible to an Integer", obj, obj.getClass().getCanonicalName()));
             }
         }
 
@@ -170,7 +178,12 @@ public final class ConfigEntry<T> implements Serializable {
 
         @Override
         public String convert(Object obj) {
-            return (String)obj;
+
+            if (obj instanceof String) {
+                return (String)obj;
+            } else {
+                return obj.toString();
+            }
         }
 
         public static Converter<String> get() {

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/errors/ConfigTypeConversionException.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/errors/ConfigTypeConversionException.java
@@ -1,0 +1,8 @@
+package com.hortonworks.registries.schemaregistry.errors;
+
+public class ConfigTypeConversionException extends RuntimeException {
+
+    public ConfigTypeConversionException(String message) { super(message); }
+
+    public ConfigTypeConversionException(String message, Throwable cause) { super(message, cause); }
+}

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/errors/ConfigTypeConversionException.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/errors/ConfigTypeConversionException.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2017-2019 Cloudera, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package com.hortonworks.registries.schemaregistry.errors;
 
 public class ConfigTypeConversionException extends RuntimeException {


### PR DESCRIPTION
During initialization property file is read into a Properties object and
validated against a predefined set of rules. However, it was implicitly
assumed, that property values can only String typed.

This fix adds the necessary conversion beside the already existing validation.

FIxes #629 