### PR TITLE
CSP-771: Upgrade HikariCP-java6 version to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
         <spring.version>5.0.7.RELEASE</spring.version>
         <postgresql.version>9.4.1212</postgresql.version>
         <flyway.version>5.1.4</flyway.version>
-        <hikari.version>2.2.5</hikari.version>
+        <hikari.version>2.3.0</hikari.version>
         <h2database.version>1.4.188</h2database.version>
         <mockito-version>1.8.5</mockito-version>
         <codehaus.plexus.version>3.1.0</codehaus.plexus.version>


### PR DESCRIPTION
* Javassist-3.18.1-GA has known `java.lang.VerifyError` issues. Upgrading the HikariCP 
   to v2.3.0 also upgrades the Javassist to 3.19.0 in which issues are fixed.