### PR TITLE
Introduce HTTP header authentication

### DIFF
--- a/common-auth/src/main/java/com/hortonworks/registries/auth/server/HttpHeaderAuthenticationHandler.java
+++ b/common-auth/src/main/java/com/hortonworks/registries/auth/server/HttpHeaderAuthenticationHandler.java
@@ -1,0 +1,259 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.hortonworks.registries.auth.server;
+
+import com.hortonworks.registries.auth.client.AuthenticationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * The <code>HttpHeaderAuthenticationHandler</code> provides a http authentication mechanism that restricts
+ * the read and write operations to input HTTP header/values received.
+ * <p>
+ * This allows to restrict the registry access from calls coming from external ingresses, where the HOST
+ * variable is populated with the ingress FQDN.
+ * </p>
+ * <p>
+ * In absence of a specific readonly section, allows read-only anonymous access from any
+ * network source.
+ * </p>
+ * <p>
+ * The resources allowed for each of the two roles (readonly, readwrite) are a Java regex and
+ * have the form: METHOD resource.
+ * </p>
+ * Configuration properties:
+ * <ul>
+ * <li>readonly.header.name: <code>HTTP header</code></li>
+ * <li>readonly.header.value: <code>header values</code></li>
+ * <li>readonly.resources: <code>Comma-separated of HTTP method and resources</code></CODE></li>
+ * <li>readwrite.header.name: <code>HTTP header</code></li>
+ * <li>readwrite.header.value: <code>header values</code></li>
+ * <li>readwrite.resources: <code>Comma-separated of HTTP method and resources</code></CODE></li>
+ * </ul>
+ * Example:
+ * <pre>
+ *   readonly.header.name: "Host"
+ *   readonly.header.value: "registry.external.mycompany.com"
+ *   readonly.resources: "GET .*, POST /api/v1/bar"
+ *
+ *   readwrite.header.name: "Host"
+ *   readwrite.header.value: "registry.internal"
+ *   readwrite.resources: "(GET|PUT|POST|DELETE) .*"
+ * </pre>
+ */
+public class HttpHeaderAuthenticationHandler implements AuthenticationHandler {
+    private static final Logger logger = LoggerFactory.getLogger(HttpHeaderAuthenticationHandler.class);
+
+    public static final String TYPE = "http";
+
+    /**
+     * Constants that identifies the access level.
+     */
+    public static final String READ_ONLY = "readonly";
+    public static final String READ_WRITE = "readwrite";
+    public static final String HEADER_NAME = "header.name";
+    public static final String HEADER_VALUE = "header.value";
+    public static final Object RESOURCES = "resources";
+
+    /**
+     * HTTP authentication realm
+     */
+    public static final String HTTP_AUTH = "Http Header Authentication";
+
+    private Optional<String> readonlyHeader = Optional.empty();
+    private Optional<String> readonlyValue = Optional.empty();
+    private Optional<String> readwriteHeader = Optional.empty();
+    private Optional<String> readwriteValue = Optional.empty();
+
+    private Collection<Pattern> readonlyResources = Collections.emptyList();
+    private Collection<Pattern> readwriteResources = Collections.emptyList();
+
+    private String type;
+
+    /**
+     * Creates an HTTP authentication handler of type <code>http</code>.
+     */
+    public HttpHeaderAuthenticationHandler() {
+        this(TYPE);
+    }
+
+    /**
+     * Creates a http authentication handler with a custom auth-token
+     * type.
+     *
+     * @param type auth-token type.
+     */
+    public HttpHeaderAuthenticationHandler(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Initializes the authentication handler instance.
+     * <p>
+     * This method is invoked by the {@link AuthenticationFilter#init} method.
+     *
+     * @param config configuration properties to initialize the handler.
+     * @throws ServletException thrown if the handler could not be initialized.
+     */
+    @Override
+    public void init(Properties config) throws ServletException {
+        readonlyHeader = getOptionalProperty(config, READ_ONLY, HEADER_NAME);
+        readonlyValue = getOptionalProperty(config, READ_ONLY, HEADER_VALUE);
+        readwriteHeader = getOptionalProperty(config, READ_WRITE, HEADER_NAME);
+        readwriteValue = getOptionalProperty(config, READ_WRITE, HEADER_VALUE);
+        readonlyResources = getPatternList(config, READ_ONLY, RESOURCES);
+        readwriteResources = getPatternList(config, READ_WRITE, RESOURCES);
+    }
+
+    private Collection<Pattern> getPatternList(Properties config, String object, Object property) {
+        return Optional.ofNullable(config.getProperty(object + "." + property))
+           .map(v -> Arrays.asList(v.split(",")))
+           .map(v -> v.stream().map(String::trim).map(Pattern::compile))
+           .map(s -> s.collect(Collectors.toList()))
+           .orElse(Collections.emptyList());
+    }
+
+    private Optional<String> getOptionalProperty(Properties config, String object, String property) {
+        return Optional.ofNullable(config.getProperty(object + "." + property));
+    }
+
+    /**
+     * Returns if the handler is configured to support anonymous users.
+     *
+     * @return if the handler is configured to support anonymous users.
+     */
+    protected boolean getAcceptAnonymous() {
+        return !readonlyHeader.isPresent();
+    }
+
+    /**
+     * Releases any resources initialized by the authentication handler.
+     * <p>
+     * This implementation does a NOP.
+     */
+    @Override
+    public void destroy() {
+    }
+
+    /**
+     * Returns the authentication type of the authentication handler, 'http'.
+     *
+     * @return the authentication type of the authentication handler, 'http'.
+     */
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * This is an empty implementation, it always returns <code>TRUE</code>.
+     *
+     * @param token    the authentication token if any, otherwise <code>NULL</code>.
+     * @param request  the HTTP client request.
+     * @param response the HTTP client response.
+     * @return <code>TRUE</code>
+     * @throws IOException             it is never thrown.
+     * @throws AuthenticationException it is never thrown.
+     */
+    @Override
+    public boolean managementOperation(AuthenticationToken token,
+                                       HttpServletRequest request,
+                                       HttpServletResponse response)
+            throws IOException, AuthenticationException {
+        return true;
+    }
+
+    private Optional<String> getUserName(HttpServletRequest request) {
+        if (readwriteHeader.isPresent() &&
+                readwriteHeader.map(request::getHeader).equals(readwriteValue)) {
+            return Optional.of(READ_WRITE);
+        }
+
+        if (readonlyHeader.isPresent() && readonlyHeader.map(request::getHeader).equals(readonlyValue)) {
+            return Optional.of(READ_ONLY);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Authenticates an HTTP client request.
+     * <p>
+     * It extracts the HTTP header parameter from the request and creates
+     * an {@link AuthenticationToken} with it.
+     * <p>
+     * If the HTTP client request does not contain the HTTP authentication header and
+     * the handler is configured to allow anonymous users it returns the {@link AuthenticationToken#ANONYMOUS}
+     * token.
+     * <p>
+     * If the HTTP client request does not contain the HTTP authentication header and
+     * the handler is configured to disallow anonymous users it throws an {@link AuthenticationException}.
+     *
+     * @param request  the HTTP client request.
+     * @param response the HTTP client response.
+     * @return an authentication token if the HTTP client request is accepted and credentials are valid.
+     * @throws IOException thrown if an IO error occurred.
+     */
+    @Override
+    public AuthenticationToken authenticate(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        logger.info("Authenticating request {}", request.getRequestURI());
+        Optional<String> username = getUserName(request);
+        Optional<AuthenticationToken> token = username.map(u -> new AuthenticationToken(u, u, getType()));
+
+        if (!token.isPresent() && !getAcceptAnonymous()) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setHeader(WWW_AUTHENTICATE, HTTP_AUTH);
+            return null;
+        }
+
+        if (!isAuthorized(username, request)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return null;
+        }
+
+        return token.orElse(AuthenticationToken.ANONYMOUS);
+    }
+
+    private boolean isAuthorized(Optional<String> username, HttpServletRequest request) {
+        String resource = String.format("%s %s", request.getMethod(), request.getPathInfo());
+
+        if (username.filter(user -> user.equals(READ_WRITE)).isPresent()) {
+            return anyMatchOf(readwriteResources, resource);
+        }
+
+        if (username.filter(user -> user.equals(READ_ONLY)).isPresent()) {
+            return anyMatchOf(readonlyResources, resource);
+        }
+
+        return getAcceptAnonymous();
+    }
+
+    private boolean anyMatchOf(Collection<Pattern> resourcePatterns, String resource) {
+        return resourcePatterns.stream().anyMatch(pattern -> pattern.matcher(resource).matches());
+    }
+
+    @Override
+    public boolean shouldAuthenticate(HttpServletRequest request) {
+        return true;
+    }
+
+}

--- a/common-auth/src/test/java/com/hortonworks/registries/auth/server/TestHttpHeaderAuthenticationHandler.java
+++ b/common-auth/src/test/java/com/hortonworks/registries/auth/server/TestHttpHeaderAuthenticationHandler.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.hortonworks.registries.auth.server;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
+
+import static com.hortonworks.registries.auth.server.HttpHeaderAuthenticationHandler.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestHttpHeaderAuthenticationHandler {
+    private static final String AUTHORIZED_RESOURCE_PATH = "/resource";
+    private static final String UNAUTHORIZED_RESOURCE_PATH = "/private/resource";
+    private static final String AUTH_HEADER = "User";
+    private static final String AUTH_VALUE = "foo";
+
+    HttpHeaderAuthenticationHandler handler;
+    Properties props;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Before
+    public void setup() throws Exception, NoSuchAlgorithmException {
+        handler = new HttpHeaderAuthenticationHandler();
+        props = new Properties();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        handler.destroy();
+    }
+
+    @Test
+    public void testAllowAnonymousAccess() throws Exception {
+        handler.init(props);
+
+        AuthenticationToken token = handler.authenticate(request,
+                response);
+        assertEquals(AuthenticationToken.ANONYMOUS, token);
+    }
+
+    @Test
+    public void testRestrictAccessToReadOnlyRole() throws Exception {
+        testRestrictAccessToRole(READ_ONLY);
+    }
+
+    @Test
+    public void testRestrictAccessToReadWriteRole() throws Exception {
+        testRestrictAccessToRole(READ_WRITE);
+    }
+
+    private void testRestrictAccessToRole(String userRole) throws Exception {
+        props.setProperty(userRole + "." + HEADER_NAME, AUTH_HEADER);
+        props.setProperty(userRole + "." + HEADER_VALUE, AUTH_VALUE);
+        props.setProperty(userRole + "." + RESOURCES, "GET " + AUTHORIZED_RESOURCE_PATH);
+        handler.init(props);
+
+        when(request.getHeader(AUTH_HEADER)).thenReturn(AUTH_VALUE);
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn(AUTHORIZED_RESOURCE_PATH);
+
+        AuthenticationToken token = handler.authenticate(request,
+                response);
+        assertNotNull(token);
+        assertEquals(userRole, token.getUserName());
+    }
+
+    @Test
+    public void testDenyAccessToReadOnlyUserForUnauthorizedHttpMethod() throws Exception {
+        testDenyAccessToRoleForUnauthorizedHttpMethod(READ_ONLY);
+    }
+
+    @Test
+    public void testDenyAccessToReadWriteUserForUnauthorizedHttpMethod() throws Exception {
+        testDenyAccessToRoleForUnauthorizedHttpMethod(READ_WRITE);
+    }
+
+    private void testDenyAccessToRoleForUnauthorizedHttpMethod(String userRole) throws Exception {
+        props.setProperty(userRole + "." + HEADER_NAME, AUTH_HEADER);
+        props.setProperty(userRole + "." + HEADER_VALUE, AUTH_VALUE);
+        props.setProperty(userRole + "." + RESOURCES, "GET " + AUTHORIZED_RESOURCE_PATH);
+        handler.init(props);
+
+        when(request.getHeader(AUTH_HEADER)).thenReturn(AUTH_VALUE);
+        when(request.getMethod()).thenReturn("PUT");
+        when(request.getPathInfo()).thenReturn(AUTHORIZED_RESOURCE_PATH);
+
+        AuthenticationToken token = handler.authenticate(request,
+                response);
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+        assertNull(token);
+    }
+
+    @Test
+    public void testDenyAccessToReadOnlyUserForUnauthorizedResource() throws Exception {
+        testDenyAccessToRoleForUnauthorizedResource(READ_ONLY);
+    }
+
+    @Test
+    public void testDenyAccessToReadWriteUserForUnauthorizedResource() throws Exception {
+        testDenyAccessToRoleForUnauthorizedResource(READ_WRITE);
+    }
+
+    private void testDenyAccessToRoleForUnauthorizedResource(String userRole) throws Exception {
+        props.setProperty(userRole + "." + HEADER_NAME, AUTH_HEADER);
+        props.setProperty(userRole + "." + HEADER_VALUE, AUTH_VALUE);
+        props.setProperty(userRole + "." + RESOURCES, "GET " + AUTHORIZED_RESOURCE_PATH);
+        handler.init(props);
+
+        when(request.getHeader(AUTH_HEADER)).thenReturn(AUTH_VALUE);
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getPathInfo()).thenReturn(UNAUTHORIZED_RESOURCE_PATH);
+
+        AuthenticationToken token = handler.authenticate(request,
+                response);
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+        assertNull(token);
+    }
+
+    @Test
+    public void testRequestAuthenticationWhenConfiguredReadOnlyUser() throws Exception {
+        props.setProperty(READ_ONLY + "." + HEADER_NAME, AUTH_HEADER);
+        props.setProperty(READ_ONLY + "." + HEADER_VALUE, AUTH_VALUE);
+        props.setProperty(READ_ONLY + "." + RESOURCES, "GET " + AUTHORIZED_RESOURCE_PATH);
+        handler.init(props);
+
+        AuthenticationToken token = handler.authenticate(request,
+                response);
+
+        assertNull(token);
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response).setHeader(WWW_AUTHENTICATE, HTTP_AUTH);
+    }
+}


### PR DESCRIPTION
ISSUE-703: Introduce HTTP header authentication
    
Allow to select read-only and read/write users based on an
arbitrary HTTP header.
    
This enable the simplest integration with K8s ingress restrictions
where traffic coming from the outside of the cluster should be allowed
to change any entry in the registry.
    
Closes #703
