### PR TITLE
CSP-1046 Upgrade third-party library versions

### DIFF
--- a/common-auth/pom.xml
+++ b/common-auth/pom.xml
@@ -129,6 +129,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
+                    <!-- default jar goal gets executed even without specifying it explicitly
                     <execution>
                         <id>prepare-jar</id>
                         <phase>prepare-package</phase>
@@ -136,6 +137,7 @@
                             <goal>jar</goal>
                         </goals>
                     </execution>
+                    -->
                     <execution>
                         <id>prepare-test-jar</id>
                         <phase>prepare-package</phase>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -49,16 +49,16 @@ limitations under the License.
                             <imageName>schema-registry</imageName>
                             <dockerDirectory>${project.basedir}/images/registry</dockerDirectory>
                             <imageTags>
-                                <imageTag>${parent.version}</imageTag>
+                                <imageTag>${project.parent.version}</imageTag>
                             </imageTags>
                             <buildArgs>
-                                <REGISTRY_VERSION>${parent.version}</REGISTRY_VERSION>
+                                <REGISTRY_VERSION>${project.parent.version}</REGISTRY_VERSION>
                             </buildArgs>
                             <resources>
                                 <resource>
                                     <targetPath>/</targetPath>
                                     <directory>${project.basedir}/../registry-dist/target</directory>
-                                    <include>hortonworks-registry-${parent.version}.tar.gz</include>
+                                    <include>hortonworks-registry-${project.parent.version}.tar.gz</include>
                                 </resource>
                             </resources>
                         </configuration>

--- a/examples/schema-registry/avro/pom.xml
+++ b/examples/schema-registry/avro/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.3.1</version>
+            <version>${commons-cli.version}</version>
         </dependency>
         <dependency>
             <groupId>com.hortonworks.registries</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -374,53 +374,51 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>4.12</junit.version>
-        <jackson.version>2.10.1</jackson.version>
-        <commons-cli.version>1.3.1</commons-cli.version>
-        <commons.version>2.5</commons.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <junit.version>4.13</junit.version>
+        <jackson.version>2.10.3</jackson.version>
+        <commons-cli.version>1.4</commons-cli.version>
+        <commons.version>2.6</commons.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <guava.version>28.1-jre</guava.version>
         <hadoop.version>3.1.1</hadoop.version>
         <kafka.version>2.1.0</kafka.version>
         <kafkaArtifact>kafka_2.11</kafkaArtifact>
         <curator.version>4.2.0</curator.version>
         <curator-test.version>4.2.0</curator-test.version>
-        <avro.version>1.9.1</avro.version>
+        <avro.version>1.9.2</avro.version>
         <dropwizard.version>1.2.8</dropwizard.version>
-        <jersey.version>2.22.1</jersey.version>
-        <jersey-media-multipart.version>2.22.1</jersey-media-multipart.version>
-        <eclipse.jetty.version>9.4.26.v20200117</eclipse.jetty.version>
-        <jmockit.version>1.19</jmockit.version>
+        <jersey.version>2.25.1</jersey.version>
+        <jersey.guava.version>2.25.1</jersey.guava.version>
+        <jersey-media-multipart.version>2.25.1</jersey-media-multipart.version>
+        <eclipse.jetty.version>9.4.27.v20200227</eclipse.jetty.version>
+        <jmockit.version>1.19</jmockit.version>  <!-- TODO 49 !!! -->
         <groovy.version>2.4.5</groovy.version>
         <hbase.version>1.1.2.2.5.0.0-1245</hbase.version>
-        <jsonschemavalidator.version>2.2.6</jsonschemavalidator.version>
-        <kryo.version>2.21</kryo.version>
+        <jsonschemavalidator.version>2.2.11</jsonschemavalidator.version>
         <logback.version>1.2.3</logback.version>
-        <phoenix.version>4.4.0-HBase-1.1</phoenix.version>
-        <mariadb-java-client.version>1.5.5</mariadb-java-client.version>
+        <mariadb-java-client.version>2.6.0</mariadb-java-client.version>
         <calcite.version>1.4.0-incubating</calcite.version>
-        <commons-codec.version>1.11</commons-codec.version>
-        <commons-lang3.version>3.4</commons-lang3.version>
-        <commons-lang.version>2.6</commons-lang.version>
+        <commons-codec.version>1.14</commons-codec.version>
+        <commons-lang3.version>3.10</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <maven-assembly-plugin.version>3.2.0</maven-assembly-plugin.version>
-        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
-        <maven-surefire.version>2.18.1</maven-surefire.version>
-        <maven-shade-plugin.version>2.4.1</maven-shade-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-        <spring.version>5.0.7.RELEASE</spring.version>
-        <postgresql.version>9.4.1212</postgresql.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-surefire.version>3.0.0-M4</maven-surefire.version>
+        <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <spring.version>5.2.5.RELEASE</spring.version>
+        <postgresql.version>42.2.12.jre7</postgresql.version>
         <flyway.version>5.1.4</flyway.version>
-        <hikari.version>2.2.5</hikari.version>
-        <h2database.version>1.4.188</h2database.version>
-        <mockito.version>2.28.2</mockito.version>
-        <powermock.version>2.0.5</powermock.version>
-        <codehaus.plexus.version>3.1.0</codehaus.plexus.version>
-        <httpclient.version>4.5.3</httpclient.version>
-        <jaxb-api.version>2.2.12</jaxb-api.version>
-        <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
+        <hikari.version>2.7.8</hikari.version>
+        <h2database.version>1.4.200</h2database.version>
+        <mockito.version>3.3.3</mockito.version>
+        <powermock.version>2.0.7</powermock.version>
+        <codehaus.plexus.version>3.3.0</codehaus.plexus.version>
+        <httpclient.version>4.5.12</httpclient.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-runtime.version>${jaxb-api.version}</jaxb-runtime.version>
     </properties>
 
     <distributionManagement>
@@ -792,21 +790,11 @@
             </dependency>
             <dependency>
               <groupId>com.zaxxer</groupId>
-              <artifactId>HikariCP-java6</artifactId>
+              <artifactId>HikariCP</artifactId>
               <version>${hikari.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>commons-lang</groupId>
-              <artifactId>commons-lang</artifactId>
-              <version>${commons-lang.version}</version>
             </dependency>
 
             <!-- Override Jetty version to synchronize dependencies -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${eclipse.jetty.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>

--- a/storage/core/pom.xml
+++ b/storage/core/pom.xml
@@ -32,15 +32,11 @@
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP-java6</artifactId>
+            <artifactId>HikariCP</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/statement/OracleDataTypeContext.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/oracle/statement/OracleDataTypeContext.java
@@ -18,7 +18,7 @@ package com.hortonworks.registries.storage.impl.jdbc.provider.oracle.statement;
 
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.storage.impl.jdbc.provider.sql.statement.DefaultStorageDataTypeContext;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSelectQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSelectQuery.java
@@ -28,7 +28,7 @@ import com.hortonworks.registries.storage.search.PredicateCombinerPair;
 import com.hortonworks.registries.storage.search.SearchQuery;
 import com.hortonworks.registries.storage.search.WhereClause;
 import com.hortonworks.registries.storage.search.WhereClauseCombiner;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.List;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSqlQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/impl/jdbc/provider/sql/query/AbstractSqlQuery.java
@@ -21,7 +21,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Collections2;
 import com.hortonworks.registries.common.Schema;
 import com.hortonworks.registries.storage.PrimaryKey;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tag-registry/pom.xml
+++ b/tag-registry/pom.xml
@@ -34,6 +34,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
+            <artifactId>jersey-guava</artifactId>
+            <version>${jersey.guava.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>compile</scope>

--- a/webservice/src/main/java/com/hortonworks/registries/webservice/RegistryApplication.java
+++ b/webservice/src/main/java/com/hortonworks/registries/webservice/RegistryApplication.java
@@ -44,7 +44,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlets.CrossOriginFilter;


### PR DESCRIPTION
- Library upgrades:
  avro 1.9.1 -> 1.9.2
  jackson 2.10.1 -> 2.10.3
  commons-cli 1.3.1 -> 1.4
  commons-io 2.5 -> 2.6
  commons-codec 1.11 -> 1.14
  commons-lang3 3.4 -> 3.10
  slf4j 1.7.25 -> 1.7.30
  jersey 2.22.1 -> 2.25.1
  jetty 9.4.26 -> 9.4.27
  jsonschemavalidator 2.2.6 -> 2.2.11
  mariadb-java-client 1.5.5 -> 2.6.0
  postgresql 9.4.1212 -> 42.2.12.jre7
  spring 5.0.7.RELEASE -> 5.2.5.RELEASE
  hikari 2.2.5 -> 2.7.8
  httpclient 4.5.3 -> 4.5.12
  jaxb-api 2.2.12 -> 2.3.1
  jaxb-runtime 2.3.1 -> 2.3.1

- Test libraries:
  junit 4.12 -> 4.13
  h2 1.4.188 -> 1.4.200
  mockito 2.28.2 -> 3.3.3
  powermock 2.0.5 -> 2.0.7
  plexus 3.1.0 -> 3.3.0

- Maven plugins:
  jar-plugin 2.6 -> 3.2.0
  surefire-plugin 2.18.1 -> 3.0.0-M4
  shade-plugin 2.4.1 -> 3.2.2
  javadoc-plugin 2.10.3 -> 3.2.0
  source-plugin 2.2.1 -> 3.2.1

- Removed commons-lang, kryo, phoenix (not used)