### PR TITLE
CDPD-10503 Upgrade nimbus-jose-jwt dependency in Schema Registry to mitigate CVEs

### DIFF
--- a/common-auth/pom.xml
+++ b/common-auth/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>4.41.1</version>
+            <version>${nimbus-jose-jwt.version}</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,7 @@
         <spring.version>5.0.7.RELEASE</spring.version>
         <postgresql.version>9.4.1212</postgresql.version>
         <flyway.version>5.1.4</flyway.version>
+        <nimbus-jose-jwt.version>7.9</nimbus-jose-jwt.version>
         <hikari.version>2.2.5</hikari.version>
         <h2database.version>1.4.188</h2database.version>
         <mockito.version>2.28.2</mockito.version>


### PR DESCRIPTION
- tested with mvn clean install
- checked the difference in dependencies, no new libraries are pulled in
- the difference is only in the version of com.nimbusds:nimbus-jose-jwt:4.41.1 -> 7.9

![diff](https://user-images.githubusercontent.com/53976741/79738511-22c69d80-82fd-11ea-9cf7-fcd04c723e35.png)
