### PR TITLE
Minor: HDFS dependencies for aws/azure file storage are missed out.

### DIFF
--- a/webservice/pom.xml
+++ b/webservice/pom.xml
@@ -23,22 +23,6 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-aws</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-azure</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-azure-datalake</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-cloud-storage</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.curator</groupId>
                     <artifactId>curator-framework</artifactId>
                 </exclusion>


### PR DESCRIPTION
The Schema registry installation package does not contain aws/azure HDFS dependencies any longer. 

When I simplified the dependencies in https://github.com/hortonworks/registry/commit/510185d7dbf314dfa9d365ca7020f791a4f4e51b, I removed the HDFS aws/azure dependencies in the `registry-common` dependent modules. I did this with the assumption that these and any newer HDFS dependent storages will be added in `registry-dist` pom.xml. Unfortunately,  I realised `registry-dist` does not package `registry-common` directly(https://github.com/hortonworks/registry/blob/master/registry-dist/pom.xml). It comes as a transitive dependency into installer package.

There are 2 ways to fix this:
1. Add `registry-common` as a direct dependency in `registry-dist` so that the installation package contains aws/azure deps too.
2. Remove exclusion of hdfs aws/azure deps from `registry-webservice` as the file storage initialization happens from there.

This patch does the latter.