### PR TITLE
Fix fingerprint method for null default values

### DIFF
--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProvider.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProvider.java
@@ -22,6 +22,7 @@ import com.hortonworks.registries.schemaregistry.SchemaCompatibility;
 import com.hortonworks.registries.schemaregistry.SchemaFieldInfo;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
@@ -180,7 +181,11 @@ public class AvroSchemaProvider extends AbstractSchemaProvider {
                     // handle default value
                     Object defaultValue = field.defaultVal();
                     if (defaultValue != null) {
-                        appendable.append(defaultValue.toString());
+                        if (defaultValue == JsonProperties.NULL_VALUE) {
+                            appendable.append("null");
+                        } else {
+                            appendable.append(defaultValue.toString());
+                        }
                     }
 
                     build(env, field.schema(), appendable).append("}");

--- a/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProviderTest.java
+++ b/schema-registry/common/src/test/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProviderTest.java
@@ -1,0 +1,44 @@
+package com.hortonworks.registries.schemaregistry.avro;
+
+import com.hortonworks.registries.schemaregistry.SchemaProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class AvroSchemaProviderTest {
+
+    private String schemaWithNullDefaults = "{\n" +
+            "  \"type\" : \"record\",\n" +
+            "  \"namespace\" : \"com.hortonworks.registries\",\n" +
+            "  \"name\" : \"trucks\",\n" +
+            "  \"fields\" : [\n" +
+            "    { \"name\" : \"driverId\" , \"type\" : [\"null\", \"int\"], \"default\": null }" +
+            "  ]\n" +
+            "}\n";
+
+    @Test
+    public void testGetFingerprintNullTypeDeterminism() throws Exception {
+        AvroSchemaProvider avroSchemaProvider = new AvroSchemaProvider();
+        avroSchemaProvider.init(Collections.singletonMap(SchemaProvider.HASH_FUNCTION_CONFIG, "MD5"));
+
+        String withNullDefaultsFingerprintHex = bytesToHex(avroSchemaProvider.getFingerprint(schemaWithNullDefaults));
+
+        Assert.assertThat(withNullDefaultsFingerprintHex, equalTo("e1e17a3aef8c728c131204bbf49046b2"));
+    }
+
+    private static String bytesToHex(byte[] hash) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : hash) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+
+}


### PR DESCRIPTION
Fixes #732 

Added a check for `null` default values to generate consistent hashes between JVM restarts.