### PR TITLE
Build reports are not always needed

### DIFF
--- a/ci/system-test/pom.xml
+++ b/ci/system-test/pom.xml
@@ -263,7 +263,7 @@
                             <key>${useDefaultListeners}</key>
                         </property>
                     </properties>
-                    <disableXmlReport>${disableXmlReport}</disableXmlReport>
+                    <disableXmlReport>true</disableXmlReport>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
