### PR TITLE
ISSUE-774 Support deserialization when the topic and schema names don't match

### DIFF
--- a/schema-registry/schema-registry-common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaResolver.java
+++ b/schema-registry/schema-registry-common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,4 +42,14 @@ public interface SchemaResolver {
      * @throws SchemaNotFoundException when any of the dependent schemas is not found.
      */
     String resolveSchema(SchemaVersionKey schemaVersionKey) throws InvalidSchemaException, SchemaNotFoundException;
+
+    /**
+
+     * @return Resolved effective schema of the given schema after resolving all the dependencies.
+     *
+     * @param schemaIdVersion {@link SchemaIdVersion} of a specific schema version for which dependencies should be resolved.
+     * @throws InvalidSchemaException  when the schema is semantically invalid or when there are cyclic dependencies.
+     * @throws SchemaNotFoundException when any of the dependent schemas is not found.
+     */
+    String resolveSchema(SchemaIdVersion schemaIdVersion) throws InvalidSchemaException, SchemaNotFoundException;
 }

--- a/schema-registry/schema-registry-common/src/main/java/com/hortonworks/registries/schemaregistry/json/JsonSchemaResolver.java
+++ b/schema-registry/schema-registry-common/src/main/java/com/hortonworks/registries/schemaregistry/json/JsonSchemaResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2021 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.hortonworks.registries.schemaregistry.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
 import com.hortonworks.registries.schemaregistry.SchemaResolver;
 import com.hortonworks.registries.schemaregistry.SchemaVersionKey;
 import com.hortonworks.registries.schemaregistry.SchemaVersionRetriever;
@@ -54,6 +55,12 @@ public class JsonSchemaResolver implements SchemaResolver {
     @Override
     public String resolveSchema(SchemaVersionKey schemaVersionKey) throws InvalidSchemaException, SchemaNotFoundException {
         String schemaText = schemaVersionRetriever.retrieveSchemaVersion(schemaVersionKey).getSchemaText();
+        return parseSchema(schemaText).toString();
+    }
+
+    @Override
+    public String resolveSchema(SchemaIdVersion schemaIdVersion) throws InvalidSchemaException, SchemaNotFoundException {
+        String schemaText = schemaVersionRetriever.retrieveSchemaVersion(schemaIdVersion).getSchemaText();
         return parseSchema(schemaText).toString();
     }
 

--- a/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotDeserializer.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2017-2021 Cloudera, Inc.
+ * Copyright 2017-2022 Cloudera, Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,9 +18,6 @@
  * limitations under the License.
  */
 package com.hortonworks.registries.schemaregistry.serdes.avro;
-
-import static com.hortonworks.registries.schemaregistry.serdes.avro.AbstractAvroSerDesProtocolHandler.READER_SCHEMA;
-import static com.hortonworks.registries.schemaregistry.serdes.avro.AbstractAvroSerDesProtocolHandler.WRITER_SCHEMA;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
@@ -44,13 +41,16 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hortonworks.registries.schemaregistry.serdes.avro.AbstractAvroSerDesProtocolHandler.READER_SCHEMA;
+import static com.hortonworks.registries.schemaregistry.serdes.avro.AbstractAvroSerDesProtocolHandler.WRITER_SCHEMA;
+
 /**
  * This class implements most of the required functionality for an avro deserializer by extending {@link AbstractSnapshotDeserializer}
  * and implementing the required methods.
  * <p>
  * <p>
  * The below example describes how to extend this deserializer with user supplied representation like MessageContext.
- * Default deserialization of avro payload is implemented in {@link #buildDeserializedObject(byte, InputStream, SchemaMetadata, Integer, Integer)}
+ * Default deserialization of avro payload is implemented in {@link #buildDeserializedObject(byte, InputStream, String, Integer, Integer)}
  * and it can be used while implementing {@link #doDeserialize(Object, byte, SchemaMetadata, Integer, Integer)} as given
  * below.
  * <p>
@@ -147,7 +147,7 @@ public abstract class AbstractAvroSnapshotDeserializer<I> extends AbstractSnapsh
      *
      * @param protocolId          protocol id
      * @param payloadInputStream  payload
-     * @param schemaMetadata      metadata about schema
+     * @param schemaName  schema name
      * @param writerSchemaVersion schema version of the writer
      * @param readerSchemaVersion schema version to be applied for reading or projection
      * @return the deserialized object
@@ -155,15 +155,14 @@ public abstract class AbstractAvroSnapshotDeserializer<I> extends AbstractSnapsh
      */
     protected Object buildDeserializedObject(byte protocolId,
                                              InputStream payloadInputStream,
-                                             SchemaMetadata schemaMetadata,
+                                             String schemaName,
                                              Integer writerSchemaVersion,
                                              Integer readerSchemaVersion) throws SerDesException {
-        String schemaName = schemaMetadata.getName();
         SchemaVersionKey writerSchemaVersionKey = new SchemaVersionKey(schemaName, writerSchemaVersion);
         LOG.debug("SchemaKey: [{}] for the received payload", writerSchemaVersionKey);
         Schema writerSchema = getSchema(writerSchemaVersionKey);
         if (writerSchema == null) {
-            throw new RegistryException("No schema exists with metadata-key: " + schemaMetadata + " and writerSchemaVersion: " + writerSchemaVersion);
+            throw new RegistryException("No schema exists with name: " + schemaName + " and writerSchemaVersion: " + writerSchemaVersion);
         }
         Schema readerSchema = readerSchemaVersion != null ? getSchema(new SchemaVersionKey(schemaName, readerSchemaVersion)) : null;
 

--- a/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroSnapshotDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/AvroSnapshotDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,6 @@
 package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
@@ -72,10 +71,10 @@ public class AvroSnapshotDeserializer extends AbstractAvroSnapshotDeserializer<I
 
     protected Object doDeserialize(InputStream payloadInputStream,
                                    byte protocolId,
-                                   SchemaMetadata schemaMetadata,
+                                   String schemaName,
                                    Integer writerSchemaVersion,
                                    Integer readerSchemaVersion) throws SerDesException {
-        return buildDeserializedObject(protocolId, payloadInputStream, schemaMetadata, writerSchemaVersion, readerSchemaVersion);
+        return buildDeserializedObject(protocolId, payloadInputStream, schemaName, writerSchemaVersion, readerSchemaVersion);
     }
     
     

--- a/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/MessageAndMetadataAvroDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/avro/MessageAndMetadataAvroDeserializer.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2017-2021 Cloudera, Inc.
+ * Copyright 2017-2022 Cloudera, Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,16 +20,20 @@
 package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.SchemaVersionInfo;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.exceptions.RegistryException;
+import com.hortonworks.registries.schemaregistry.serde.AbstractSerDes;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import com.hortonworks.registries.schemaregistry.serdes.avro.exceptions.AvroException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 
 public class MessageAndMetadataAvroDeserializer extends AbstractAvroSnapshotDeserializer<MessageAndMetadata> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSerDes.class);
 
     public MessageAndMetadataAvroDeserializer() {
     }
@@ -43,24 +47,27 @@ public class MessageAndMetadataAvroDeserializer extends AbstractAvroSnapshotDese
                               Integer readerSchemaVersion) throws SerDesException {
         byte protocolId = retrieveProtocolId(context);
         SchemaIdVersion schemaIdVersion = retrieveSchemaIdVersion(protocolId, context);
-        SchemaMetadata schemaMetadata;
-        SchemaVersionInfo schemaVersionInfo;
+
         try {
-            schemaVersionInfo = schemaRegistryClient.getSchemaVersionInfo(schemaIdVersion);
-            schemaMetadata = schemaRegistryClient.getSchemaMetadataInfo(schemaVersionInfo.getName()).getSchemaMetadata();
+            SchemaVersionInfo schemaVersionInfo = schemaRegistryClient.getSchemaVersionInfo(schemaIdVersion);
+            return doDeserialize(
+                    context,
+                    protocolId,
+                    schemaVersionInfo.getName(),
+                    schemaVersionInfo.getVersion(),
+                    readerSchemaVersion);
         } catch (Exception e) {
             throw new RegistryException(e);
         }
-        return doDeserialize(context, protocolId, schemaMetadata, schemaVersionInfo.getVersion(), readerSchemaVersion);
     }
 
     @Override
     protected Object doDeserialize(MessageAndMetadata context,
                                    byte protocolId,
-                                   SchemaMetadata schemaMetadata,
+                                   String schemaName,
                                    Integer writerSchemaVersion,
                                    Integer readerSchemaVersion) throws SerDesException {
-        return buildDeserializedObject(protocolId, new ByteArrayInputStream(context.payload()), schemaMetadata,
+        return buildDeserializedObject(protocolId, new ByteArrayInputStream(context.payload()), schemaName,
                 writerSchemaVersion, readerSchemaVersion);
     }
 

--- a/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/json/AbstractJsonSnapshotDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/json/AbstractJsonSnapshotDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.hortonworks.registries.schemaregistry.serdes.json;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.SchemaVersionInfo;
 import com.hortonworks.registries.schemaregistry.SchemaVersionKey;
 import com.hortonworks.registries.schemaregistry.SchemaVersionRetriever;
@@ -85,17 +84,16 @@ public abstract class AbstractJsonSnapshotDeserializer<I> extends AbstractSnapsh
 
   protected Object buildDeserializedObject(byte protocolId,
                                            InputStream payloadInputStream,
-                                           SchemaMetadata schemaMetadata,
+                                           String schemaName,
                                            Integer schemaVersion) throws SerDesException {
 
 
 
-    String schemaName = schemaMetadata.getName();
     SchemaVersionKey schemaVersionKey = new SchemaVersionKey(schemaName, schemaVersion);
     LOG.debug("SchemaKey: [{}] for the received payload", schemaVersionKey);
     Schema writerSchema = getSchema(schemaVersionKey);
     if (writerSchema == null) {
-      throw new RegistryException("No schema exists with metadata-key: " + schemaMetadata + " and schemaVersion: " + schemaVersionKey);
+      throw new RegistryException("No schema exists with name: " + schemaName + " and schemaVersion: " + schemaVersionKey);
     }
 
     return deserializePayloadForProtocol(protocolId, payloadInputStream, writerSchema);

--- a/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/json/JsonSnapshotDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/json/JsonSnapshotDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2021 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.hortonworks.registries.schemaregistry.serdes.json;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.SchemaVersionKey;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.json.JsonSchemaResolver;
@@ -43,8 +42,7 @@ public class JsonSnapshotDeserializer extends AbstractJsonSnapshotDeserializer<I
     }
 
     @Override
-    protected Object doDeserialize(InputStream input, byte protocolId, SchemaMetadata schemaMetadata, Integer writerSchemaVersion, Integer readerSchemaVersion) throws SerDesException {
-        String schemaName = schemaMetadata.getName();
+    protected Object doDeserialize(InputStream input, byte protocolId, String schemaName, Integer writerSchemaVersion, Integer readerSchemaVersion) throws SerDesException {
         SchemaVersionKey versionKey = new SchemaVersionKey(schemaName, writerSchemaVersion);
         try {
             Schema json = getParsedSchema(versionKey);

--- a/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/json/MessageAndMetadataJsonDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/main/java/com/hortonworks/registries/schemaregistry/serdes/json/MessageAndMetadataJsonDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.hortonworks.registries.schemaregistry.serdes.json;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.SchemaVersionInfo;
 import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.exceptions.RegistryException;
@@ -46,21 +45,23 @@ public class MessageAndMetadataJsonDeserializer extends AbstractJsonSnapshotDese
     }
 
     SchemaIdVersion schemaIdVersion = retrieveSchemaIdVersion(protocolId, context);
-    SchemaMetadata schemaMetadata;
-    SchemaVersionInfo schemaVersionInfo;
     try {
-      schemaVersionInfo = schemaRegistryClient.getSchemaVersionInfo(schemaIdVersion);
-      schemaMetadata = schemaRegistryClient.getSchemaMetadataInfo(schemaVersionInfo.getName()).getSchemaMetadata();
+      SchemaVersionInfo schemaVersionInfo = schemaRegistryClient.getSchemaVersionInfo(schemaIdVersion);
+      return doDeserialize(
+              context,
+              protocolId,
+              schemaVersionInfo.getName(),
+              schemaVersionInfo.getVersion(),
+              readerSchemaVersion);
     } catch (Exception e) {
       throw new RegistryException(e);
     }
-    return doDeserialize(context, protocolId, schemaMetadata, schemaVersionInfo.getVersion(), readerSchemaVersion);
   }
 
   @Override
   protected Object doDeserialize(MessageAndMetadata context,
                                  byte protocolId,
-                                 SchemaMetadata schemaMetadata,
+                                 String schemaName,
                                  Integer writerSchemaVersion,
                                  Integer readerSchemaVersion) throws SerDesException {
 
@@ -68,7 +69,7 @@ public class MessageAndMetadataJsonDeserializer extends AbstractJsonSnapshotDese
       throw new SerDesException("Illegal protocol: " + protocolId);
     }
 
-    return buildDeserializedObject(protocolId, new ByteArrayInputStream(context.payload()), schemaMetadata,
+    return buildDeserializedObject(protocolId, new ByteArrayInputStream(context.payload()), schemaName,
         writerSchemaVersion);
   }
 

--- a/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/MessageContextBasedAvroDeserializer.java
+++ b/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/avro/serdes/MessageContextBasedAvroDeserializer.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2017-2021 Cloudera, Inc.
+ * Copyright 2017-2022 Cloudera, Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,7 +20,6 @@
 package com.hortonworks.registries.schemaregistry.avro.serdes;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.client.SchemaRegistryClient;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import com.hortonworks.registries.schemaregistry.serdes.avro.AbstractAvroSnapshotDeserializer;
@@ -37,12 +36,12 @@ public class MessageContextBasedAvroDeserializer extends AbstractAvroSnapshotDes
     @Override
     protected Object doDeserialize(MessageContext input,
                                    byte protocolId,
-                                   SchemaMetadata schemaMetadata,
+                                   String schemaName,
                                    Integer writerSchemaVersion,
                                    Integer readerSchemaVersion) throws SerDesException {
         return buildDeserializedObject(protocolId,
                 input.payloadEntity,
-                schemaMetadata,
+                schemaName,
                 writerSchemaVersion, readerSchemaVersion);
     }
 

--- a/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serde/AbstractSnapshotDeserializerTest.java
+++ b/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serde/AbstractSnapshotDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Cloudera, Inc.
+ * Copyright 2017-2022 Cloudera, Inc.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,7 +20,6 @@
 package com.hortonworks.registries.schemaregistry.serde;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.SchemaVersionKey;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
@@ -166,7 +165,7 @@ public class AbstractSnapshotDeserializerTest {
         }
 
         @Override
-        protected Object doDeserialize(Object input, byte protocolId, SchemaMetadata schemaMetadata, Integer writerSchemaVersion, Integer readerSchemaVersion) throws SerDesException {
+        protected Object doDeserialize(Object input, byte protocolId, String schemaName, Integer writerSchemaVersion, Integer readerSchemaVersion) throws SerDesException {
             return null;
         }
 

--- a/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotDeserializerTest.java
+++ b/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serdes/avro/AbstractAvroSnapshotDeserializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2020 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,6 @@
 package com.hortonworks.registries.schemaregistry.serdes.avro;
 
 import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
-import com.hortonworks.registries.schemaregistry.SchemaMetadata;
 import com.hortonworks.registries.schemaregistry.serde.SerDesException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -66,7 +65,7 @@ public class AbstractAvroSnapshotDeserializerTest {
     
     class AvroSnapshotDeserializer extends AbstractAvroSnapshotDeserializer<String> {
         @Override
-        protected Object doDeserialize(String input, byte protocolId, SchemaMetadata schemaMetadata, Integer writerSchemaVersion, Integer readerSchemaVersion) throws SerDesException {
+        protected Object doDeserialize(String input, byte protocolId, String schemaName, Integer writerSchemaVersion, Integer readerSchemaVersion) throws SerDesException {
             return null;
         }
 

--- a/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serdes/avro/kafka/KafkaAvroDeserializerTest.java
+++ b/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serdes/avro/kafka/KafkaAvroDeserializerTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2016-2022 Cloudera, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package com.hortonworks.registries.schemaregistry.serdes.avro.kafka;
+
+import com.hortonworks.registries.schemaregistry.SchemaIdVersion;
+import com.hortonworks.registries.schemaregistry.SchemaMetadata;
+import com.hortonworks.registries.schemaregistry.SchemaVersion;
+import com.hortonworks.registries.schemaregistry.SchemaVersionInfo;
+import com.hortonworks.registries.schemaregistry.SchemaVersionKey;
+import com.hortonworks.registries.schemaregistry.client.ISchemaRegistryClient;
+import com.hortonworks.registries.schemaregistry.errors.IncompatibleSchemaException;
+import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
+import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
+import com.hortonworks.registries.schemaregistry.exceptions.RegistryException;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.util.Utf8;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class KafkaAvroDeserializerTest {
+
+    @DisplayName("Should deserialize even if topic name does not match the schema name")
+    @Test
+    public void shouldDeserializeEvenWhenSchemaNameDoesNotMatchTopicName() throws SchemaNotFoundException, IncompatibleSchemaException, InvalidSchemaException, IOException {
+        long schemaVersionId = 1L;
+        String schemaName = "[schema-name]";
+        int versionNth = 1;
+        ISchemaRegistryClient client = mockClientThatDoesntFindMetadata(
+                schemaVersionId,
+                schemaName,
+                schema.toString(),
+                versionNth);
+        KafkaAvroDeserializer deser = new KafkaAvroDeserializer(client);
+        deser.configure(emptyMap(), false);
+        String topicName = "[topic-name]";
+
+        Object deserialized = deser.deserialize(topicName, avro(client, topicName, avroRecord));
+        Assertions.assertEquals(avroRecord, deserialized);
+        verify(client).getSchemaVersionInfo(eq(new SchemaIdVersion(schemaVersionId)));
+        verify(client).getSchemaVersionInfo(eq(new SchemaVersionKey(schemaName, versionNth)));
+        verify(client, never()).getSchemaMetadataInfo(anyString());
+    }
+
+    private ISchemaRegistryClient mockClientThatDoesntFindMetadata(long schemaVersionId,
+                                                                   String schemaName,
+                                                                   String schemaText,
+                                                                   int versionNth) throws SchemaNotFoundException, IncompatibleSchemaException, InvalidSchemaException {
+        ISchemaRegistryClient mock = Mockito.mock(ISchemaRegistryClient.class);
+        SchemaVersionInfo schemaVersionInfo = new SchemaVersionInfo(schemaVersionId,
+                schemaName,
+                versionNth,
+                schemaText,
+                currentTimeMillis(),
+                "[description]");
+        when(mock.getSchemaVersionInfo(Mockito.any(SchemaIdVersion.class))).thenReturn(schemaVersionInfo);
+        when(mock.getSchemaVersionInfo(Mockito.any(SchemaVersionKey.class))).thenReturn(schemaVersionInfo);
+        RegistryException exception = new RegistryException("[schema not found]");
+        when(mock.getSchemaMetadataInfo(schemaVersionInfo.getName())).thenThrow(exception);
+        when(mock.addSchemaVersion(any(SchemaMetadata.class), any(SchemaVersion.class))).thenReturn(new SchemaIdVersion(schemaVersionId));
+        return mock;
+    }
+
+    private byte[] avro(ISchemaRegistryClient client, String topicName, Object toSerialize) throws IOException {
+        KafkaAvroSerializer serializer = new KafkaAvroSerializer(client);
+        serializer.configure(emptyMap(), false);
+        return serializer.serialize(topicName, toSerialize);
+    }
+
+    private Schema schema = SchemaBuilder
+            .record("myrecord")
+            .fields()
+            .optionalString("field")
+            .endRecord();
+
+    private GenericRecord avroRecord = new GenericRecordBuilder(schema)
+            .set("field", new Utf8("[string-value]"))
+            .build();
+}

--- a/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serdes/json/JsonSnapshotDeserializerTest.java
+++ b/schema-registry/schema-registry-serdes/src/test/java/com/hortonworks/registries/schemaregistry/serdes/json/JsonSnapshotDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Cloudera, Inc.
+ * Copyright 2016-2022 Cloudera, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ class JsonSnapshotDeserializerTest {
     Mockito.when(jsonSerDesHandlerMock.handlePayloadDeserialization(any(InputStream.class), any(Schema.class))).thenReturn(jsonNodeDeserialized);
     
     //when
-    Object deserialized = underTest.doDeserialize(is, Byte.parseByte("4"), metadata, 1, 0);
+    Object deserialized = underTest.doDeserialize(is, Byte.parseByte("4"), metadata.getName(), 1, 0);
     
     //then
     ObjectNode expected = JsonNodeFactory.instance.objectNode()


### PR DESCRIPTION
Refactor the serdes code so it allows deserializing even when the topic and schema name doesn’t match. A major and long standing annoyance with our Deserializer.